### PR TITLE
Encrypt annotation data payloads on encrypted channels

### DIFF
--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -9,7 +9,6 @@ import RestAnnotations, { RestGetAnnotationsParams, constructValidateAnnotation 
 import type { PaginatedResult } from './paginatedresource';
 import type Message from '../types/message';
 import type { Properties } from '../util/utils';
-import type { CipherOptions } from '../types/basemessage';
 
 class RealtimeAnnotations {
   private channel: RealtimeChannel;
@@ -25,7 +24,7 @@ class RealtimeAnnotations {
   async publish(msgOrSerial: string | Message, annotationValues: Partial<Properties<Annotation>>): Promise<void> {
     const channelName = this.channel.name;
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues, 'publish');
-    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions);
 
     this.channel.throwIfUnpublishableState();
 

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -9,6 +9,7 @@ import RestAnnotations, { RestGetAnnotationsParams, constructValidateAnnotation 
 import type { PaginatedResult } from './paginatedresource';
 import type Message from '../types/message';
 import type { Properties } from '../util/utils';
+import type { CipherOptions } from '../types/basemessage';
 
 class RealtimeAnnotations {
   private channel: RealtimeChannel;
@@ -24,7 +25,7 @@ class RealtimeAnnotations {
   async publish(msgOrSerial: string | Message, annotationValues: Partial<Properties<Annotation>>): Promise<void> {
     const channelName = this.channel.name;
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues);
-    const wireAnnotation = await annotation.encode();
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
 
     this.channel.throwIfUnpublishableState();
 

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -9,7 +9,6 @@ import RestAnnotations, { RestGetAnnotationsParams, constructValidateAnnotation 
 import type { PaginatedResult } from './paginatedresource';
 import type Message from '../types/message';
 import type { Properties } from '../util/utils';
-import type { CipherOptions } from '../types/basemessage';
 
 class RealtimeAnnotations {
   private channel: RealtimeChannel;
@@ -25,7 +24,7 @@ class RealtimeAnnotations {
   async publish(msgOrSerial: string | Message, annotationValues: Partial<Properties<Annotation>>): Promise<void> {
     const channelName = this.channel.name;
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues);
-    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions);
 
     this.channel.throwIfUnpublishableState();
 

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -9,6 +9,7 @@ import RestAnnotations, { RestGetAnnotationsParams, constructValidateAnnotation 
 import type { PaginatedResult } from './paginatedresource';
 import type Message from '../types/message';
 import type { Properties } from '../util/utils';
+import type { CipherOptions } from '../types/basemessage';
 
 class RealtimeAnnotations {
   private channel: RealtimeChannel;
@@ -24,7 +25,7 @@ class RealtimeAnnotations {
   async publish(msgOrSerial: string | Message, annotationValues: Partial<Properties<Annotation>>): Promise<void> {
     const channelName = this.channel.name;
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues, 'publish');
-    const wireAnnotation = await annotation.encode();
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
 
     this.channel.throwIfUnpublishableState();
 

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -3,7 +3,7 @@ import ProtocolMessage, { fromValues as protocolMessageFromValues } from '../typ
 import EventEmitter from '../util/eventemitter';
 import * as Utils from '../util/utils';
 import Logger from '../util/logger';
-import { EncodingDecodingContext, CipherOptions, populateFieldsFromParent } from '../types/basemessage';
+import { EncodingDecodingContext, populateFieldsFromParent } from '../types/basemessage';
 import Message, { getMessagesSize, encodeArray as encodeMessagesArray } from '../types/message';
 import ChannelStateChange from './channelstatechange';
 import ErrorInfo, { PartialErrorInfo } from '../types/errorinfo';
@@ -302,8 +302,7 @@ class RealtimeChannel extends EventEmitter {
       });
     }
     const maxMessageSize = this.client.options.maxMessageSize;
-    // TODO get rid of CipherOptions type assertion, indicates channeloptions types are broken
-    const wireMessages = await encodeMessagesArray(messages, this.channelOptions as CipherOptions);
+    const wireMessages = await encodeMessagesArray(messages, this.channelOptions);
     /* RSL1i */
     const size = getMessagesSize(wireMessages);
     if (size > maxMessageSize) {
@@ -1225,7 +1224,7 @@ class RealtimeChannel extends EventEmitter {
       version: operation,
     });
 
-    const wireMessage = await updateDeleteMsg.encode(this.channelOptions as CipherOptions);
+    const wireMessage = await updateDeleteMsg.encode(this.channelOptions);
     const pm = protocolMessageFromValues({
       action: actions.MESSAGE,
       channel: this.name,

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -3,7 +3,7 @@ import ProtocolMessage, { fromValues as protocolMessageFromValues } from '../typ
 import EventEmitter from '../util/eventemitter';
 import * as Utils from '../util/utils';
 import Logger from '../util/logger';
-import { EncodingDecodingContext, CipherOptions, populateFieldsFromParent } from '../types/basemessage';
+import { EncodingDecodingContext, populateFieldsFromParent } from '../types/basemessage';
 import Message, { getMessagesSize, encodeArray as encodeMessagesArray } from '../types/message';
 import ChannelStateChange from './channelstatechange';
 import ErrorInfo, { PartialErrorInfo } from '../types/errorinfo';
@@ -304,8 +304,7 @@ class RealtimeChannel extends EventEmitter {
       });
     }
     const maxMessageSize = this.client.options.maxMessageSize;
-    // TODO get rid of CipherOptions type assertion, indicates channeloptions types are broken
-    const wireMessages = await encodeMessagesArray(messages, this.channelOptions as CipherOptions);
+    const wireMessages = await encodeMessagesArray(messages, this.channelOptions);
     /* RSL1i */
     const size = getMessagesSize(wireMessages);
     if (size > maxMessageSize) {
@@ -1228,7 +1227,7 @@ class RealtimeChannel extends EventEmitter {
       version: operation,
     });
 
-    const wireMessage = await updateDeleteMsg.encode(this.channelOptions as CipherOptions);
+    const wireMessage = await updateDeleteMsg.encode(this.channelOptions);
     const pm = protocolMessageFromValues({
       action: actions.MESSAGE,
       channel: this.name,

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -2,7 +2,6 @@ import * as Utils from '../util/utils';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
 import PresenceMessage, { WirePresenceMessage } from '../types/presencemessage';
-import type { CipherOptions } from '../types/basemessage';
 import ErrorInfo, { PartialErrorInfo } from '../types/errorinfo';
 import { flags } from '../types/protocolmessagecommon';
 import RealtimeChannel from './realtimechannel';
@@ -127,7 +126,7 @@ class RealtimePresence extends EventEmitter {
     if (clientId) {
       presence.clientId = clientId;
     }
-    const wirePresMsg = await presence.encode(channel.channelOptions as CipherOptions);
+    const wirePresMsg = await presence.encode(channel.channelOptions);
 
     switch (channel.state) {
       case 'attached':
@@ -195,7 +194,7 @@ class RealtimePresence extends EventEmitter {
     if (clientId) {
       presence.clientId = clientId;
     }
-    const wirePresMsg = await presence.encode(channel.channelOptions as CipherOptions);
+    const wirePresMsg = await presence.encode(channel.channelOptions);
 
     switch (channel.state) {
       case 'attached':

--- a/src/common/lib/client/restannotations.ts
+++ b/src/common/lib/client/restannotations.ts
@@ -7,7 +7,6 @@ import Defaults from '../util/defaults';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
 import Resource from './resource';
 import type { Properties } from '../util/utils';
-import type { CipherOptions } from '../types/basemessage';
 import ErrorInfo from '../types/errorinfo';
 
 export interface RestGetAnnotationsParams {
@@ -88,7 +87,7 @@ class RestAnnotations {
     methodName: string,
   ): Promise<void> {
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues, methodName);
-    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions);
 
     const client = this.channel.client,
       options = client.options,

--- a/src/common/lib/client/restannotations.ts
+++ b/src/common/lib/client/restannotations.ts
@@ -7,7 +7,6 @@ import Defaults from '../util/defaults';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
 import Resource from './resource';
 import type { Properties } from '../util/utils';
-import type { CipherOptions } from '../types/basemessage';
 import ErrorInfo from '../types/errorinfo';
 
 export interface RestGetAnnotationsParams {
@@ -76,7 +75,7 @@ class RestAnnotations {
 
   async publish(msgOrSerial: string | Message, annotationValues: Partial<Properties<Annotation>>): Promise<void> {
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues);
-    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions);
 
     const client = this.channel.client,
       options = client.options,

--- a/src/common/lib/client/restannotations.ts
+++ b/src/common/lib/client/restannotations.ts
@@ -7,6 +7,7 @@ import Defaults from '../util/defaults';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
 import Resource from './resource';
 import type { Properties } from '../util/utils';
+import type { CipherOptions } from '../types/basemessage';
 import ErrorInfo from '../types/errorinfo';
 
 export interface RestGetAnnotationsParams {
@@ -75,7 +76,7 @@ class RestAnnotations {
 
   async publish(msgOrSerial: string | Message, annotationValues: Partial<Properties<Annotation>>): Promise<void> {
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues);
-    const wireAnnotation = await annotation.encode();
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
 
     const client = this.channel.client,
       options = client.options,

--- a/src/common/lib/client/restannotations.ts
+++ b/src/common/lib/client/restannotations.ts
@@ -7,6 +7,7 @@ import Defaults from '../util/defaults';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
 import Resource from './resource';
 import type { Properties } from '../util/utils';
+import type { CipherOptions } from '../types/basemessage';
 import ErrorInfo from '../types/errorinfo';
 
 export interface RestGetAnnotationsParams {
@@ -87,7 +88,7 @@ class RestAnnotations {
     methodName: string,
   ): Promise<void> {
     const annotation = constructValidateAnnotation(msgOrSerial, annotationValues, methodName);
-    const wireAnnotation = await annotation.encode();
+    const wireAnnotation = await annotation.encode(this.channel.channelOptions as CipherOptions);
 
     const client = this.channel.client,
       options = client.options,

--- a/src/common/lib/client/restchannel.ts
+++ b/src/common/lib/client/restchannel.ts
@@ -6,7 +6,6 @@ import Message, {
   getMessagesSize,
   encodeArray as encodeMessagesArray,
 } from '../types/message';
-import { CipherOptions } from '../types/basemessage';
 import ErrorInfo from '../types/errorinfo';
 import { PaginatedResult } from './paginatedresource';
 import Resource from './resource';
@@ -136,7 +135,7 @@ class RestChannel {
       });
     }
 
-    const wireMessages = await encodeMessagesArray(messages, this.channelOptions as CipherOptions);
+    const wireMessages = await encodeMessagesArray(messages, this.channelOptions);
 
     /* RSL1i */
     const size = getMessagesSize(wireMessages),

--- a/src/common/lib/client/restchannelmixin.ts
+++ b/src/common/lib/client/restchannelmixin.ts
@@ -4,7 +4,6 @@ import ErrorInfo from '../types/errorinfo';
 import RealtimeChannel from './realtimechannel';
 import * as Utils from '../util/utils';
 import Message, { WireMessage, _fromEncodedArray, _fromEncoded, serialize as serializeMessage } from '../types/message';
-import { CipherOptions } from '../types/basemessage';
 import Defaults from '../util/defaults';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
 import Resource from './resource';
@@ -118,7 +117,7 @@ export class RestChannelMixin {
     requestMessage.action = action;
     requestMessage.version = operation;
 
-    const encoded = await requestMessage.encode(channel.channelOptions as CipherOptions);
+    const encoded = await requestMessage.encode(channel.channelOptions);
     const requestBody = serializeMessage(encoded, client._MsgPack, format);
 
     let method = Resource.patch;

--- a/src/common/lib/types/annotation.ts
+++ b/src/common/lib/types/annotation.ts
@@ -1,5 +1,5 @@
 import Logger from '../util/logger';
-import { BaseMessage, encode, decode, wireToJSON, strMsg } from './basemessage';
+import { BaseMessage, encode, decode, wireToJSON, strMsg, CipherOptions } from './basemessage';
 import * as API from '../../../../ably';
 import * as Utils from '../util/utils';
 
@@ -62,13 +62,11 @@ class Annotation extends BaseMessage {
   name?: string;
   count?: number;
 
-  async encode(): Promise<WireAnnotation> {
+  async encode(options: CipherOptions): Promise<WireAnnotation> {
     const res = Object.assign(new WireAnnotation(), this, {
       action: actions.indexOf(this.action || 'annotation.create'),
     });
-    // note: we do not pass cipheroptions/channeloptions here as annotations are not
-    // encrypted (as the data needs to be parsed by the server for summarisation)
-    return encode(res, {});
+    return encode(res, options);
   }
 
   static fromValues(values: Properties<Annotation>): Annotation {

--- a/src/common/lib/types/annotation.ts
+++ b/src/common/lib/types/annotation.ts
@@ -1,5 +1,5 @@
 import Logger from '../util/logger';
-import { BaseMessage, encode, decode, wireToJSON, strMsg, CipherOptions } from './basemessage';
+import { BaseMessage, encode, decode, wireToJSON, strMsg } from './basemessage';
 import * as API from '../../../../ably';
 import * as Utils from '../util/utils';
 
@@ -62,7 +62,7 @@ class Annotation extends BaseMessage {
   name?: string;
   count?: number;
 
-  async encode(options: CipherOptions): Promise<WireAnnotation> {
+  async encode(options: ChannelOptions): Promise<WireAnnotation> {
     const res = Object.assign(new WireAnnotation(), this, {
       action: actions.indexOf(this.action || 'annotation.create'),
     });

--- a/src/common/lib/types/basemessage.ts
+++ b/src/common/lib/types/basemessage.ts
@@ -19,8 +19,12 @@ export type EncryptedChannelOptions = ChannelOptions & {
   channelCipher: NonNullable<ChannelOptions['channelCipher']>;
 };
 
+/**
+ * Both fields are set together by normaliseChannelOptions and normalizeCipherOptions, but options
+ * that have bypassed those are not necessarily consistent, so check both.
+ */
 export function isEncrypted(options: ChannelOptions | null | undefined): options is EncryptedChannelOptions {
-  return !!options && !!options.cipher;
+  return !!options && !!options.cipher && !!options.channelCipher;
 }
 
 export type EncodingDecodingContext = {

--- a/src/common/lib/types/basemessage.ts
+++ b/src/common/lib/types/basemessage.ts
@@ -10,18 +10,18 @@ import type { IUntypedCryptoStatic } from 'common/types/ICryptoStatic';
 import type { ChannelOptions } from '../../types/channel';
 import type ProtocolMessage from './protocolmessage';
 
-export type CipherOptions = {
-  channelCipher: {
-    encrypt: Function;
-    algorithm: 'aes';
-  };
-  cipher?: {
-    channelCipher: {
-      encrypt: Function;
-      algorithm: 'aes';
-    };
-  };
+/**
+ * ChannelOptions on which encryption is fully configured, so a payload can be encrypted without
+ * further checks. Narrow to this with isEncrypted().
+ */
+export type EncryptedChannelOptions = ChannelOptions & {
+  cipher: API.CipherParams;
+  channelCipher: NonNullable<ChannelOptions['channelCipher']>;
 };
+
+export function isEncrypted(options: ChannelOptions | null | undefined): options is EncryptedChannelOptions {
+  return !!options && !!options.cipher;
+}
 
 export type EncodingDecodingContext = {
   channelOptions: ChannelOptions;
@@ -33,7 +33,7 @@ export type EncodingDecodingContext = {
   baseEncodedPreviousPayload?: Buffer | BrowserBufferlike;
 };
 
-function normaliseContext(context: CipherOptions | EncodingDecodingContext | ChannelOptions): EncodingDecodingContext {
+function normaliseContext(context: EncodingDecodingContext | ChannelOptions): EncodingDecodingContext {
   if (!context || !(context as EncodingDecodingContext).channelOptions) {
     return {
       channelOptions: context as ChannelOptions,
@@ -60,7 +60,7 @@ export function normalizeCipherOptions(
   return options ?? {};
 }
 
-async function encrypt<T extends BaseMessage>(msg: T, cipherOptions: CipherOptions): Promise<T> {
+async function encrypt<T extends BaseMessage>(msg: T, cipherOptions: EncryptedChannelOptions): Promise<T> {
   const { data, encoding } = await encryptData(msg.data, msg.encoding, cipherOptions);
   msg.data = data;
   msg.encoding = encoding;
@@ -70,7 +70,7 @@ async function encrypt<T extends BaseMessage>(msg: T, cipherOptions: CipherOptio
 export async function encryptData(
   data: any,
   encoding: string | null | undefined,
-  cipherOptions: CipherOptions,
+  cipherOptions: EncryptedChannelOptions,
 ): Promise<{ data: any; encoding: string | null | undefined }> {
   let cipher = cipherOptions.channelCipher;
   let dataToEncrypt = data;
@@ -94,14 +94,14 @@ export async function encryptData(
  * Encodes and encrypts message's payload. Mutates the message object.
  * Implements RSL4 and RSL5.
  */
-export async function encode<T extends BaseMessage>(msg: T, options: unknown): Promise<T> {
+export async function encode<T extends BaseMessage>(msg: T, options: ChannelOptions | null): Promise<T> {
   const { data, encoding } = encodeData(msg.data, msg.encoding);
 
   msg.data = data;
   msg.encoding = encoding;
 
-  if (options != null && (options as CipherOptions).cipher) {
-    return encrypt(msg, options as CipherOptions);
+  if (isEncrypted(options)) {
+    return encrypt(msg, options);
   } else {
     return msg;
   }
@@ -143,7 +143,7 @@ export function encodeData(
 
 export async function decode<T extends BaseMessage>(
   message: T,
-  inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions,
+  inputContext: EncodingDecodingContext | ChannelOptions,
 ): Promise<void> {
   // data can be decoded partially and throw an error on a later decoding step.
   // so we need to reassign the data and encoding values we got, and only then throw an error if there is one
@@ -162,7 +162,7 @@ export async function decode<T extends BaseMessage>(
 export async function decodeData(
   data: any,
   encoding: string | null | undefined,
-  inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions,
+  inputContext: EncodingDecodingContext | ChannelOptions,
 ): Promise<{
   error?: ErrorInfo;
   data: any;

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -6,7 +6,6 @@ import {
   wireToJSON,
   normalizeCipherOptions,
   EncodingDecodingContext,
-  CipherOptions,
   strMsg,
 } from './basemessage';
 import * as Utils from '../util/utils';
@@ -93,7 +92,7 @@ export async function _fromEncodedArray(encodedArray: Properties<WireMessage>[],
   );
 }
 
-export async function encodeArray(messages: Array<Message>, options: CipherOptions): Promise<Array<WireMessage>> {
+export async function encodeArray(messages: Array<Message>, options: ChannelOptions): Promise<Array<WireMessage>> {
   return Promise.all(messages.map((message) => message.encode(options)));
 }
 
@@ -164,7 +163,7 @@ class Message extends BaseMessage {
     }
   }
 
-  async encode(options: CipherOptions): Promise<WireMessage> {
+  async encode(options: ChannelOptions): Promise<WireMessage> {
     const res = Object.assign(new WireMessage(), this, {
       action: actions.indexOf(this.action || 'message.create'),
     });
@@ -207,7 +206,7 @@ export class WireMessage extends BaseMessage {
 
   // for contexts where some decoding errors need to be handled specially by the caller
   async decodeWithErr(
-    inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions,
+    inputContext: EncodingDecodingContext | ChannelOptions,
     logger: Logger,
   ): Promise<{ decoded: Message; err: ErrorInfo | undefined }> {
     const res: Message = Object.assign(new Message(), {
@@ -225,10 +224,7 @@ export class WireMessage extends BaseMessage {
     return { decoded: res, err: err };
   }
 
-  async decode(
-    inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions,
-    logger: Logger,
-  ): Promise<Message> {
+  async decode(inputContext: EncodingDecodingContext | ChannelOptions, logger: Logger): Promise<Message> {
     const { decoded } = await this.decodeWithErr(inputContext, logger);
     return decoded;
   }

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -1,5 +1,5 @@
 import Logger from '../util/logger';
-import { BaseMessage, encode, decode, wireToJSON, normalizeCipherOptions, CipherOptions, strMsg } from './basemessage';
+import { BaseMessage, encode, decode, wireToJSON, normalizeCipherOptions, strMsg } from './basemessage';
 import * as API from '../../../../ably';
 import * as Utils from '../util/utils';
 
@@ -87,7 +87,7 @@ class PresenceMessage extends BaseMessage {
     };
   }
 
-  async encode(options: CipherOptions): Promise<WirePresenceMessage> {
+  async encode(options: ChannelOptions): Promise<WirePresenceMessage> {
     const res = Object.assign(new WirePresenceMessage(), this, {
       action: actions.indexOf(this.action || 'present'),
     });

--- a/test/realtime/annotations.test.js
+++ b/test/realtime/annotations.test.js
@@ -1,7 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (Helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
   const { assert } = chai;
+  const Crypto = Ably.Realtime.Platform.Crypto;
   describe('realtime/annotations', function () {
     this.timeout(10 * 1000);
     let rest, helper, realtime;
@@ -67,6 +68,123 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       assert.equal(annotation.type, 'reaction:distinct.v1');
       assert.equal(annotation.name, '😕');
       assert.ok(annotation.serial > annotation.messageSerial);
+    });
+
+    it('annotation data payloads round-trip on an encrypted channel', async () => {
+      const key = await Crypto.generateRandomKey();
+      const channelName = 'mutable:annotation_encrypted_data';
+      const channel = realtime.channels.get(channelName, {
+        cipher: { key },
+        modes: ['publish', 'subscribe', 'annotation_publish', 'annotation_subscribe'],
+      });
+      const restChannel = rest.channels.get(channelName, { cipher: { key } });
+      await channel.attach();
+      const onMessage = channel.subscriptions.once();
+      let onAnnotation = channel.annotations.subscriptions.once();
+
+      await channel.publish('message', 'foobar');
+      const message = await onMessage;
+      assert.equal(message.data, 'foobar', 'check message data decrypted');
+
+      // Temporary anti-flake measure; can be removed after summary loop implements
+      // annotation resume (CHA-887)
+      await helper.setTimeoutAsync(1000);
+
+      await channel.annotations.publish(message, {
+        type: 'reaction:distinct.v1',
+        name: '👍',
+        data: 'realtime annotation data',
+      });
+      let annotation = await onAnnotation;
+      assert.equal(
+        annotation.data,
+        'realtime annotation data',
+        'check realtime-published annotation data round-tripped',
+      );
+
+      // and again via the rest publish path
+      onAnnotation = channel.annotations.subscriptions.once();
+      await restChannel.annotations.publish(message, {
+        type: 'reaction:distinct.v1',
+        name: '😕',
+        data: 'rest annotation data',
+      });
+      annotation = await onAnnotation;
+      assert.equal(annotation.data, 'rest annotation data', 'check rest-published annotation data round-tripped');
+    });
+
+    /* A round-trip test cannot catch a failure to encrypt: an unencrypted payload
+     * decodes to itself, so publish and subscribe stay mutually consistent. Assert
+     * on the serialized annotation as it leaves the client instead. */
+    it('annotation data is encrypted on the wire on an encrypted channel', async () => {
+      const key = await Crypto.generateRandomKey();
+      const channelName = 'mutable:annotation_wire_encryption';
+      const plaintext = 'super-secret-annotation-data';
+
+      const channel = realtime.channels.get(channelName, {
+        cipher: { key },
+        modes: ['publish', 'subscribe', 'annotation_publish', 'annotation_subscribe'],
+      });
+      // text protocol so the intercepted rest body can be parsed as JSON
+      const jsonRest = helper.AblyRest({ clientId: Helper.randomString(10), useBinaryProtocol: false });
+      const restChannel = jsonRest.channels.get(channelName, { cipher: { key } });
+      await channel.attach();
+      const onMessage = channel.subscriptions.once();
+      await channel.publish('message', 'foobar');
+      const message = await onMessage;
+
+      const assertEncrypted = function (wireAnnotation, description) {
+        assert.exists(wireAnnotation, 'check outgoing annotation was intercepted for ' + description);
+        assert.include(
+          wireAnnotation.encoding || '',
+          'cipher+aes-256-cbc',
+          'check ' + description + ' annotation declares a cipher encoding',
+        );
+        assert.notInclude(
+          JSON.stringify(wireAnnotation.data),
+          plaintext,
+          'check ' + description + ' annotation data is not sent in plaintext',
+        );
+      };
+
+      // realtime publish path: intercept the outgoing ANNOTATION protocol message
+      let sentAnnotation;
+      const connectionManager = realtime.connection.connectionManager;
+      helper.recordPrivateApi('replace.connectionManager.send');
+      const sendOrig = connectionManager.send;
+      connectionManager.send = function (msg, queueEvent, callback) {
+        if (msg.action === 21 /* ANNOTATION */ && msg.annotations) {
+          sentAnnotation = msg.annotations[0];
+        }
+        helper.recordPrivateApi('call.connectionManager.send');
+        sendOrig.call(connectionManager, msg, queueEvent, callback);
+      };
+
+      try {
+        await channel.annotations.publish(message, { type: 'reaction:distinct.v1', name: '👍', data: plaintext });
+      } finally {
+        connectionManager.send = sendOrig;
+      }
+      assertEncrypted(sentAnnotation, 'realtime-published');
+
+      // rest publish path: intercept the serialized request body
+      let postedAnnotation;
+      helper.recordPrivateApi('replace.rest.http.do');
+      const httpDoOrig = jsonRest.http.do;
+      jsonRest.http.do = function (method, path, headers, body, params) {
+        if (path.includes('/annotations') && body) {
+          postedAnnotation = JSON.parse(body)[0];
+        }
+        helper.recordPrivateApi('call.rest.http.do');
+        return httpDoOrig.call(jsonRest.http, method, path, headers, body, params);
+      };
+
+      try {
+        await restChannel.annotations.publish(message, { type: 'reaction:distinct.v1', name: '😕', data: plaintext });
+      } finally {
+        jsonRest.http.do = httpDoOrig;
+      }
+      assertEncrypted(postedAnnotation, 'rest-published');
     });
 
     it('get all annotations rest request', async () => {

--- a/test/realtime/annotations.test.js
+++ b/test/realtime/annotations.test.js
@@ -41,10 +41,6 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       const message = await onMessage;
       onMessage = channel.subscriptions.once();
 
-      // Temporary anti-flake measure; can be removed after summary loop implements
-      // annotation resume (CHA-887)
-      await helper.setTimeoutAsync(1000);
-
       await channel.annotations.publish(message, { type: 'reaction:distinct.v1', name: '👍' });
       let annotation = await onAnnotation;
       assert.equal(annotation.action, 'annotation.create');
@@ -85,10 +81,6 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       await channel.publish('message', 'foobar');
       const message = await onMessage;
       assert.equal(message.data, 'foobar', 'check message data decrypted');
-
-      // Temporary anti-flake measure; can be removed after summary loop implements
-      // annotation resume (CHA-887)
-      await helper.setTimeoutAsync(1000);
 
       await channel.annotations.publish(message, {
         type: 'reaction:distinct.v1',


### PR DESCRIPTION
Annotation `data` payloads were published in plaintext even on channels with a cipher configured.

This was, originally, deliberate and documented that annotations would be exempt from e2e encryption, since the multiple.v1 annotation type used data payloads like `{"count":1}`, so the server had to read them.

Before the public release I argued for changing that API so aggregation didn't use `data`, specifically to stop the server having to parse payloads and to preserve the "Ably never reads your payload" property, and pointed to the ability to do end-to-end encryption as a benefit of the change. That was agreed and I implemented it in ably-js in April 2025 (adding the `count` field), but I forgot to actually enable e2e encryption at the same time, which would then have been possible. So the rationale for disabling e2e encryption for annotations no longer applies.

Before releasing, we need to either confirm nobody is using annotation `data` payloads on encrypted channels or contact anyone who is, cf PUB-3816 and https://github.com/ably/realtime/pull/8575.

Also fixed the CipherOptions type which has been broken since the typescriptification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Annotation data now respects channel encryption settings when published through Realtime and REST.
  * Improved encryption handling for messages, presence updates, and annotations.
  * Prevented annotation data from being exposed as plaintext in transmitted payloads.
  * Improved annotation validation and channel state handling during resumed connections.

* **Tests**
  * Added coverage confirming encrypted annotation data round-trips correctly.
  * Added checks that annotation payloads do not contain plaintext data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->