### PR TITLE
test/uts: push activation UTS suite (75 derived tests) + push deviations

### DIFF
--- a/test/uts/deviations.md
+++ b/test/uts/deviations.md
@@ -204,6 +204,160 @@ These tests assert spec behavior but are skipped by default because they are kno
 
 ---
 
+### push: RSH1b3/RSH1b5/RSH1c3/RSH1c4 - admin operations for the local device lack push device authentication
+
+**Spec (RSH1b3, RSH1b5, RSH1c3, RSH1c4)**: When the client has been activated as a push target device and an admin operation (`deviceRegistrations.save/remove/removeWhere`, `channelSubscriptions.save/remove`) references the present client's own `deviceId`, the request must include push device authentication (RSH6).
+
+**ably-js behavior**: `DeviceRegistrations` and `ChannelSubscriptions` (`src/common/lib/client/push.ts`) never add device-auth headers; the local device is not consulted when building admin requests.
+
+**Tests**: `push_device_auth.test.ts` — `RSH6a/admin-device-registrations-save-own-device-0`, `RSH6a/admin-channel-subscriptions-save-own-device-2`, `RSH6a/admin-remove-where-own-device-3`: the header assertions are `RUN_DEVIATIONS`-guarded (the rest of each test passes; observed admin request headers carry only basic key auth).
+
+**Fix**: planned as a separate PR. Note ably-java conforms (Android `Push.pushRequestHeaders(deviceId)` merges `X-Ably-DeviceToken` when the deviceId is the local device's).
+
+---
+
+### push: RSH3h/RSH8a1 - corrupt persisted state neither discarded nor survivable
+
+**Spec (RSH3h, RSH8a1)**: If loading the `LocalDevice` `id` or `deviceSecret` fails, all persisted LocalDevice attributes and all persisted machine data must be discarded, so the machine starts in `NotActivated`; an unrecognised persisted machine state must likewise fall back, never crash.
+
+**ably-js behavior**: two gaps. (1) `loadPersistedAsync()` loads an incomplete pair (seeded `deviceId`, missing `deviceSecret`) without discarding anything — the stale identity token and machine state are honoured, so `activate()` resolves immediately with zero requests. (2) Machine rehydration does `new ActivationStates[name]()` (`src/plugins/push/pushactivation.ts:314`); an unrecognised `ably.push.activationState` value throws `TypeError: ... is not a constructor`, rejecting `activate()` outright.
+
+**Tests**: `RSH8a1 - corrupt device state is discarded`, `RSH8a1 - unrecognised machine state falls back to NotActivated` (`push_activation_persistence.test.ts`), skipped via `RUN_DEVIATIONS`.
+
+**Fix**: planned as a separate PR.
+
+---
+
+### push: RSH3a2a/RSH3f1 - re-activation registration sync not implemented
+
+**Spec (RSH3a2a, RSH3a2a1–RSH3a2a4, RSH3f1a)**: `CalledActivate` on a device that already has a `deviceIdentityToken` validates the registration: the RSH3d3b PATCH sync (or custom `registerCallback`), preceded by the RSH3a2a1 clientId-compatibility check (61002), transitioning through `WaitingForRegistrationSync`.
+
+**ably-js behavior**: `NotActivated` + `CalledActivate` with a registered device re-queues the event into `WaitingForNewPushDeviceDetails`, which resolves `activate()` immediately — no sync request, no `registerCallback` validation call. The 61002 check exists (`pushactivation.ts:678`) but is dead code: `loadPersistedAsync()` overwrites `device.clientId` with the present client's `auth.clientId` (line 194) and clientId is never persisted, so a mismatch can never be observed. Consequently `AfterRegistrationSyncFailed` is unreachable via `activate()` (it is reachable via a failed `updateToken` sync).
+
+**Tests** (all `RUN_DEVIATIONS`-skipped): `RSH3a2a3/activate-existing-registration-sync-0`, `RSH3a2a2/...-register-callback-0`, `RSH3a2a1/activate-clientid-mismatch-0`, `RSH3e3c/sync-failure-then-reactivate-0`, `RSH3f2a/deactivate-after-sync-failure-0`, `RSH3g3b/deregister-failure-rollback-after-sync-failed-1` (`push_activation_state_machine.test.ts`); `RSH4/second-activate-queued-during-activate-sync-1` (`push_activation_event_queue.test.ts`).
+
+**Fix**: planned as a separate PR (implement the sync per the amended RSH3a2a3 — a PATCH, which ably-js's existing `updateRegistration()` already performs elsewhere).
+
+---
+
+### push: RSH3b1a/RSH3c1a/RSH3g1a - concurrent activate/deactivate rejected instead of coalesced
+
+**Spec**: a repeated `CalledActivate`/`CalledDeactivate` while one is in flight self-transitions; both calls resolve when the operation completes.
+
+**ably-js behavior**: `Push.activate()`/`deactivate()` reject a second concurrent call with ErrorInfo 40000 "Activation/Deactivation already in progress" (`src/common/lib/client/push.ts:67-74, 116-123`) before any event reaches the machine. Core single-request behaviour conforms.
+
+**Tests**: assertion-level guards in `RSH3b1a/activate-while-waiting-push-details-0`, `RSH3c1a/activate-while-registering-0`, `RSH3g1a/deactivate-while-deregistering-0` — the adapted branch asserts the 40000 rejection.
+
+---
+
+### push: RSH6a/RSH6b/RSH3d2b - device auth via bearer Authorization; no deviceSecret auth; no-token registration crashes
+
+**Spec (RSH6a)**: device auth adds an `X-Ably-DeviceToken` header carrying the `deviceIdentityToken`. **(RSH6b)**: with a `deviceSecret` but no identity token, `X-Ably-DeviceSecret` is used instead.
+
+**ably-js behavior**: the activation plugin's PATCH/DELETE use `authorization: Bearer base64(deviceIdentityToken)` (`pushactivation.ts:253`), or an `access_token` param; only `LocalDevice.listSubscriptions()` uses `X-Ably-DeviceToken` (`pushactivation.ts:126`). Observed live through the proxy: the device bearer **replaces** the client's key/token auth on those requests (both write the lowercase `authorization` header), so per RSH3d2b no other auth is present — and it works against the real service only because the `deviceIdentityToken` is itself an Ably token, authenticating as ordinary token auth rather than via the device-auth path (the same bearer is NOT accepted as device auth on `/push/channelSubscriptions`). There is no `X-Ably-DeviceSecret` path: `getAuthDetails` throws 50000 without an identity token, outside `deregister()`'s try/catch, so `deactivate()` never settles. Additionally, a `registerCallback` result lacking `deviceIdentityToken` crashes the machine (`TypeError` at `pushactivation.ts:776` via nextTick; `activate()` never settles) — the guard at line 384 only rejects a falsy registration.
+
+**Tests**: assertion-level guards in `RSH2b/deactivate-full-flow-0`, `RSH3d3b/update-token-patch-0` (adapted branch asserts the bearer header); full skip `RSH6b/device-secret-auth-before-identity-token-0` (`push_device_auth.test.ts`).
+
+**Fix**: header form planned as a separate PR; note ably-java/ably-cocoa send `X-Ably-DeviceToken` with a **base64-encoded** value, which RSH6a's wording doesn't mention — spec clarification needed on the value encoding.
+
+---
+
+### push: RSH3a1c - deactivate from NotActivated does not deregister a registered device
+
+**Spec (RSH3a1c)**: in `NotActivated`, on `CalledDeactivate`, a device with a `deviceIdentityToken` deregisters per RSH3d2.
+
+**ably-js behavior**: `NotActivated` resolves `CalledDeactivate` immediately without checking for a `deviceIdentityToken` — zero requests where the spec expects a DELETE with device auth.
+
+**Tests**: `RSH3a1c/deactivate-not-activated-with-token-0`, skipped via `RUN_DEVIATIONS`.
+
+---
+
+### push: RSH3d2c1 - deregistration status classification unimplemented
+
+**Spec (RSH3d2c1)**: `Deregistered` on 2xx, 401, or error code 40005; `DeregistrationFailed` otherwise.
+
+**ably-js behavior**: `deregister()` fires `DeregistrationFailed` on any request error — a 401 or 40005 DELETE makes `deactivate()` reject and roll back instead of clearing the registration.
+
+**Tests**: `RSH3d2c1/deregister-401-succeeds-0`, `RSH3d2c1/deregister-40005-succeeds-1` (unit), and `rest/proxy/RSH3d2c1/deregister-401-classified-0`, `rest/proxy/RSH3d2c1/deregister-40005-classified-1` (`test/uts/rest/integration/proxy/push_activation.test.ts` — observed live through the proxy: deactivate() rejects with the injected 40100/40005 error and rolls back), all skipped via `RUN_DEVIATIONS`.
+
+---
+
+### push: RSH3a2b - deviceSecret entropy below spec
+
+**Spec (RSH3a2b)**: `deviceSecret` must be created from secure random data with a digest of at least 32 bytes, base64-encoded.
+
+**ably-js behavior**: `resetId()` generates a ulid (26-char Crockford base32, ~19 bytes when base64-decoded per the test's method), well short of the 32-byte digest requirement.
+
+**Tests**: assertion-level guard in `RSH3a2b/device-id-secret-generation-0` (uniqueness assertions pass).
+
+---
+
+### push: RSH8d/RSH8e/RSH8f - clientId lifecycle not wired into LocalDevice
+
+**Spec**: a `clientId` learned late (RSA7b2/RSA7b3, per RSH8d) is set and persisted on the LocalDevice, triggering a registration sync when registered (RSH8e); a `clientId` in the registration response is adopted (RSH8f).
+
+**ably-js behavior**: `GotDeviceRegistration` captures only `deviceIdentityToken` — a response `clientId` is discarded (RSH8f). There is no hook from auth into the LocalDevice, and `auth.clientId` is not derived from TokenDetails at all (same root cause as the RSA7b deviation, issue [#2192](https://github.com/ably/ably-js/issues/2192)) — a late-identified token is silently ignored by the push layer (RSH8d/RSH8e).
+
+**Tests**: `RSH8f/clientid-from-registration-response-0`, `RSH8d/late-clientid-persisted-0`, `RSH8e/late-clientid-triggers-sync-0` (`local_device.test.ts`), skipped via `RUN_DEVIATIONS`.
+
+---
+
+### push: RSH8a - partial persisted state not loaded (recipient ignored without a device id)
+
+**Spec (RSH8a)**: the LocalDevice attributes are populated from persisted state "to the extent that they exist" — a persisted `ably.push.pushRecipient` with no id/secret pair is a legitimate partial state (consumed by RSH3a2c, which then skips the platform token request).
+
+**ably-js behavior**: `loadPersistedAsync()` reads `ably.push.pushRecipient` (and the identity token) only when `ably.push.deviceId` is persisted (`pushactivation.ts:196-206`); otherwise it calls `resetId()` and never reads the recipient, so activation falls through to `getPushDeviceDetails`/`requestToken`.
+
+**Tests**: `test/uts/rest/integration/push_activation.test.ts` seeds a deviceId/deviceSecret pair alongside the recipient as a workaround (DEVIATION-commented); ably-dart exhibited the same gap and was fixed.
+
+**Fix**: candidate for the same PR as the RSH3h/RSH8a1 discard fixes.
+
+---
+
+### push: AfterRegistrationSyncFailed not persisted
+
+**Spec**: which machine states are persisted is not prescribed, but the UTS suite observes settled state via the persisted `ably.push.activationState`.
+
+**ably-js behavior**: only `NotActivated` and `WaitingForNewPushDeviceDetails` are persistent (`isPersistentState`, `pushactivation.ts:896`); after a failed sync the persisted value still reads `WaitingForNewPushDeviceDetails`.
+
+**Tests**: assertion-level guards where the spec asserts a persisted `AfterRegistrationSyncFailed` (`push_update_token.test.ts` sync-failure test; `rest/proxy/RSH3e3d/sync-failure-recovery-0` in `test/uts/rest/integration/proxy/push_activation.test.ts`).
+
+---
+
+### push: RSH8l/PCP3a/PDT4 - APNs token variants unimplemented (pending token-variants spec extension)
+
+**Spec (PDT4, PCP3a, RSH8l2 — pending extension)**: `updateToken` with `apnsTokenType` targets a recipient slot in `apnsDeviceTokens`, preserving other registered variants.
+
+**ably-js behavior**: `apnsTokenType` is silently ignored; `updateToken({transportType: 'apns', token, apnsTokenType: 'pushToStart'})` resolves and PATCHes `{push: {recipient: {transportType: 'apns', deviceToken: token}}}` — clobbering the default token; no `apnsDeviceTokens` map exists (`push.ts:194-197` unconditionally replaces the recipient).
+
+**Tests**: `RSH8l2/update-token-push-to-start-10`, `RSH8l2/update-token-variant-preserves-others-11`, skipped via `RUN_DEVIATIONS`.
+
+**Fix**: to follow the token-variants spec extension PR.
+
+---
+
+### push_types: PCP2/PCP4/PCS5 - push type surface differences
+
+**Spec**: `DevicePushDetails.errorReason` (`ErrorInfo`), `state` enum (`Active`/`Failing`/`Failed`), `PushChannelSubscription.forDevice`/`forClientId` factories with exactly-one enforcement (PCS5); `DeviceDetails.metadata` a string map (PCD5).
+
+**ably-js behavior**: `fromValues` converts only a top-level `error` to `ErrorInfo` — a `push.errorReason` passes through as a plain object, and `toJSON()` writes the push error as `push.error`, dropping a spec-named `errorReason` from serialization; there is no `DevicePushState` enum (raw uppercase wire strings `ACTIVE`/`FAILING`/`FAILED`); the PCS5 factories do not exist (`fromValues` copies as-received, no exactly-one enforcement); `metadata` is *typed* `string` but round-trips a map at runtime (type-level only).
+
+**Tests**: assertion-level guards in `rest/unit/types/push_types.test.ts` (factories constructed via `fromValues` per the spec's sanctioned equivalent).
+
+---
+
+### push: RSH3e2c/RSH3e3d - updatedCallback not implemented (only the deprecated updateFailedCallback)
+
+**Spec (RSH3e2c, RSH3e3d)**: `Push#activate` accepts an `updatedCallback` which is called with no error on `RegistrationSynced` (when the sync was not triggered by `CalledActivate`) and with the error on `SyncRegistrationFailed`. RSH3e3a (`updateFailedCallback`, failure-only) is deprecated.
+
+**ably-js behavior**: `push.activate(registerCallback, updateFailedCallback)` exposes only the deprecated failure-only callback; there is no success notification path for background registration syncs.
+
+**Tests**: `push_update_token.test.ts` — `RSH3e3d/update-token-sync-failure-callback-4`: failure delivery adapted to `updateFailedCallback` (passes); the RSH3e2c success-callback assertion is `RUN_DEVIATIONS`-guarded.
+
+**Fix**: planned as a separate PR (additive: accept `updatedCallback`, keep `updateFailedCallback` as a deprecated alias for the failure case).
+
+---
+
 ### integration/push_admin: RSH1b2 - push device list pagination missing Link headers
 
 **Spec (RSH1b2)**: `deviceRegistrations.list` with `limit` should support pagination via `hasNext()`.
@@ -213,6 +367,16 @@ These tests assert spec behavior but are skipped by default because they are kno
 **Test**: `RSH1b2 - list supports pagination with limit` in `rest/integration/push_admin.test.ts`.
 
 **Issue**: [ably/realtime#8380](https://github.com/ably/realtime/issues/8380)
+
+---
+
+### integration/push_activation: registration-update PATCH rejected for ablyChannel-recipient devices (server issue, fixed pending deploy)
+
+**Server behavior**: `PATCH /push/deviceRegistrations/:deviceId` fails with 400 (code 40000, `unknown transport type 'ablyChannel'`) for any device whose **stored** recipient is `ablyChannel`, regardless of the PATCH body — so the registration sync can never land against an `ablyChannel`-registered device.
+
+**Tests**: `rest/integration/RSH2f/update-token-synced-0` (`rest/integration/push_activation.test.ts`) and `rest/proxy/RSH3e3d/sync-failure-recovery-0` (`rest/integration/proxy/push_activation.test.ts`), both of which sync a rotated token against an `ablyChannel`-seeded device. Skipped unconditionally (`this.skip()`) until the fix is deployed to the sandbox, then unskip.
+
+**Issue**: [ably/realtime#8591](https://github.com/ably/realtime/pull/8591) (fix merged, pending sandbox deploy)
 
 ---
 
@@ -268,9 +432,9 @@ The wire protocol uses numeric operation actions and JSON-stringified `json`/`in
 
 ## Mock Infrastructure Limitations
 
-### MsgPack encoding/decoding not supported
+### MsgPack encoding/decoding not supported (in this repo's harness — not a UTS limitation)
 
-The UTS mock HTTP infrastructure operates at the JSON level. It has no mechanism to encode/decode msgpack binary format.
+The UTS mock HTTP contract supports msgpack: `PendingRequest.body` is bytes, responses can carry raw byte bodies with a Content-Type, and the specs use `msgpack_encode`/`msgpack_decode` harness helpers (see the msgpack unit tests in `uts/rest/unit/{encoding/message_encoding.md, auth/token_renewal.md, presence/rest_presence.md, rest_client.md}`). It is **this repo's port** (`test/uts/mock_http.ts`) that operates at the JSON level (`respond_with` JSON-stringifies bodies; `PendingRequest.body` is `string | null`). Catch-up work: extend the mock to byte bodies and wire `@ably/msgpack-js` (already a dependency, and the platform's own msgpack implementation) as the encode/decode helpers, then implement the skipped tests below.
 
 **Tests affected (10 skipped)**:
 

--- a/test/uts/rest/integration/proxy/push_activation.test.ts
+++ b/test/uts/rest/integration/proxy/push_activation.test.ts
@@ -1,0 +1,691 @@
+/**
+ * UTS Proxy Integration: Push Activation Tests
+ *
+ * Spec points: RSH3a2c, RSH3c3a, RSH3d2c1, RSH3e3d, RSH3f1, RSH3g2a, RSH3g3b, RSH4
+ * Source: specification/uts/rest/integration/proxy/push_activation.md
+ *
+ * These tests drive the real push activation state machine (via the
+ * ReactNativePush plugin carrying a MockPushStorage) against the Ably sandbox
+ * THROUGH the uts-proxy, injecting faults on the registration endpoints. A
+ * direct admin client (bypassing the proxy) provides server-side ground
+ * truth — e.g. proving a faulted DELETE never reached the server.
+ *
+ * Per the spec's seeded-recipient design (RSH3a2c), storage is pre-seeded
+ * with an ablyChannel push recipient so `requestToken` is never consulted.
+ * The proxy serves plain HTTP, so clients authenticate via an authCallback
+ * whose inner client talks directly to the sandbox (RSA1: no Basic auth over
+ * an insecure connection).
+ */
+
+import { expect } from 'chai';
+import {
+  Ably,
+  SANDBOX_ENDPOINT,
+  setupSandbox,
+  teardownSandbox,
+  getApiKey,
+  pollUntil,
+  pollUntilSuccess,
+} from '../sandbox';
+import { MockPushStorage, installReactNativeFake, restoreReactNativeFake } from '../../unit/push/push_helpers';
+import ReactNativePush from '../../../../../src/plugins/react-native-push';
+import { createProxySession, waitForProxy, ProxySession, ProxyEvent } from '../../../realtime/integration/helpers/proxy';
+
+const SANDBOX_REST_URL = 'https://sandbox.realtime.ably-nonprod.net';
+
+function randomId(): string {
+  return Math.random().toString(36).substring(2, 10);
+}
+
+/**
+ * UTS `ably_channel_recipient(channel_name)`: the server-consumable recipient
+ * pre-seeded into storage. ablyUrl is the DIRECT sandbox URL — never the
+ * proxy — since it is consumed server-side.
+ */
+function ablyChannelRecipient(channelName: string): Record<string, string> {
+  return {
+    transportType: 'ablyChannel',
+    channel: channelName,
+    ablyKey: getApiKey(0),
+    ablyUrl: SANDBOX_REST_URL,
+  };
+}
+
+/**
+ * Storage pre-seeded with a push recipient — a first-ever activation with
+ * known push details (RSH3a2c).
+ *
+ * DEVIATION (RSH8a): the spec seeds only ably.push.pushRecipient — a partial
+ * persisted state implementations must tolerate ("to the extent that they
+ * exist"). ably-js does not: LocalDevice.loadPersistedAsync() reads
+ * pushRecipient only when ably.push.deviceId is present in storage
+ * (src/plugins/push/pushactivation.ts:196-206; the no-id branch calls
+ * resetId() and never reads the recipient key), so activate() over a
+ * recipient-only seed falls through to requestToken and rejects with
+ * "Failed to get react-native push device details: requestToken must not be
+ * called: recipient is pre-seeded (RSH3a2c)" (verified against the sandbox).
+ * Adapted by also seeding deviceId/deviceSecret (their eager generation is
+ * sanctioned by the spec's RSH8k2 note); the seeded-recipient design and all
+ * server interactions are otherwise unchanged.
+ */
+function seededStorage(recipient: Record<string, string>): MockPushStorage {
+  const storage = new MockPushStorage();
+  storage.seed({
+    'ably.push.pushRecipient': JSON.stringify(recipient),
+    'ably.push.deviceId': 'uts-device-' + randomId(),
+    'ably.push.deviceSecret': 'uts-secret-' + randomId() + randomId(),
+  });
+  return storage;
+}
+
+/**
+ * UTS `proxy_push_client(session, storage, channel_name, recipient?)`: a push
+ * client routed through the proxy over pre-seeded storage. Token auth via an
+ * authCallback whose inner client talks DIRECTLY to the sandbox, so token
+ * requests are never intercepted by fault-injection rules. endpoint:
+ * "localhost" auto-disables fallback hosts (REC2c2).
+ */
+function proxyPushClient(session: ProxySession, storage: MockPushStorage): any {
+  const plugin = ReactNativePush.create({
+    storage,
+    requestToken: async () => {
+      throw new Error('requestToken must not be called: recipient is pre-seeded (RSH3a2c)');
+    },
+  });
+  return new Ably.Rest({
+    authCallback: (_params: any, cb: any) => {
+      const innerRest = new Ably.Rest({ key: getApiKey(0), endpoint: SANDBOX_ENDPOINT } as any);
+      innerRest.auth.requestToken().then(
+        (token: any) => cb(null, token),
+        (err: any) => cb(err, null),
+      );
+    },
+    endpoint: 'localhost',
+    port: session.proxyPort,
+    tls: false,
+    useBinaryProtocol: false,
+    plugins: { Push: plugin },
+  } as any);
+}
+
+/**
+ * UTS `direct_admin_client()`: an admin client that bypasses the proxy
+ * entirely — the source of server-side ground truth for these tests.
+ */
+function directAdminClient(): any {
+  return new Ably.Rest({
+    key: getApiKey(0),
+    endpoint: SANDBOX_ENDPOINT,
+    useBinaryProtocol: false,
+  });
+}
+
+/**
+ * UTS `activate_through_proxy(client, storage)`: runs a fully real activation
+ * through the proxy (no rules firing) and returns the registered device id.
+ */
+async function activateThroughProxy(client: any, storage: MockPushStorage): Promise<string> {
+  await client.push.activate();
+  await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails', {
+    interval: 100,
+    timeout: 10000,
+  });
+  return storage.dump()['ably.push.deviceId'];
+}
+
+function registrationRequests(log: ProxyEvent[], method?: string): ProxyEvent[] {
+  return log.filter(
+    (e) =>
+      e.type === 'http_request' &&
+      !!e.path &&
+      e.path.includes('/push/deviceRegistrations') &&
+      (!method || (e.method ?? '').toUpperCase() === method),
+  );
+}
+
+describe('uts/rest/integration/proxy/push_activation', function () {
+  this.timeout(120000);
+
+  let session: ProxySession | null = null;
+
+  before(async function () {
+    // The ReactNativePush plugin resolves require('react-native').Platform.OS
+    // inside create(); fake the module for the whole suite (platform: android).
+    installReactNativeFake();
+    await waitForProxy();
+    await setupSandbox();
+  });
+
+  after(async function () {
+    restoreReactNativeFake();
+    await teardownSandbox();
+  });
+
+  afterEach(async function () {
+    if (session) {
+      await session.close();
+      session = null;
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH3d2c1 — deregistration 401 is classified as Deregistered without the
+  // DELETE reaching the server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH3d2c1, RSH3g2a - a fully real activation registers the device through
+   * the proxy; the proxy then answers the deregistration DELETE with a
+   * synthetic 401 without forwarding it. deactivate() must resolve and clear
+   * local state — and the server-side registration must still exist, proving
+   * the 401 → Deregistered classification is purely client-side.
+   *
+   * DEVIATION: see deviations.md "push: RSH3d2c1 - deregistration status
+   * classification unimplemented" — ably-js's deregister() fires
+   * DeregistrationFailed on ANY request error, so deactivate() REJECTS on the
+   * injected 401 (observed against the sandbox: ErrorInfo code 40100,
+   * statusCode 401, message "unauthorized") and rolls back to
+   * WaitingForNewPushDeviceDetails instead of resolving and clearing the
+   * registration.
+   */
+  // UTS: rest/proxy/RSH3d2c1/deregister-401-classified-0
+  it('RSH3d2c1 - deregistration 401 is classified as Deregistered without the DELETE reaching the server', async function () {
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+    session = await createProxySession();
+
+    const channelName = 'push-proxy-RSH3d2c1-401-' + randomId();
+    const storage = seededStorage(ablyChannelRecipient(channelName));
+    const client = proxyPushClient(session, storage);
+    const admin = directAdminClient();
+
+    // Real registration through the proxy
+    const deviceId = await activateThroughProxy(client, storage);
+
+    try {
+      // Server-side ground truth: the registration exists
+      const registered = await admin.push.admin.deviceRegistrations.get(deviceId);
+      expect(registered.id).to.equal(deviceId);
+
+      // Late fault injection: only the deregistration DELETE is faulted
+      await session.addRules([
+        {
+          match: { type: 'http_request', method: 'DELETE', pathContains: '/push/deviceRegistrations' },
+          action: {
+            type: 'http_respond',
+            status: 401,
+            body: { error: { message: 'unauthorized', code: 40100, statusCode: 401 } },
+          },
+          times: 1,
+          comment: 'RSH3d2c1: answer the deregistration DELETE with 401 without forwarding it',
+        },
+      ]);
+
+      // Resolves despite the 401 — classified as Deregistered
+      await client.push.deactivate();
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'NotActivated', {
+        interval: 100,
+        timeout: 10000,
+      });
+
+      // RSH3g2a — local state cleared
+      const persisted = storage.dump();
+      expect(persisted).to.not.have.property('ably.push.deviceIdentityToken');
+      expect(persisted).to.not.have.property('ably.push.pushRecipient');
+
+      // The DELETE never reached the server: the registration STILL exists.
+      // The 401 → Deregistered classification is purely client-side.
+      const stillRegistered = await admin.push.admin.deviceRegistrations.get(deviceId);
+      expect(stillRegistered.id).to.equal(deviceId);
+
+      // The proxy log confirms exactly one DELETE was issued (and answered by the rule)
+      const log = await session.getLog();
+      expect(registrationRequests(log, 'DELETE').length).to.equal(1);
+    } finally {
+      // Best-effort cleanup of the orphaned server-side registration
+      await admin.push.admin.deviceRegistrations.remove(deviceId).catch(() => {});
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH3d2c1 — deregistration error code 40005 is classified as Deregistered
+  // without the DELETE reaching the server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH3d2c1, RSH3g2a - as deregister-401-classified-0, but the injected
+   * fault is an HTTP 400 whose body carries error code 40005 — exercising the
+   * body-code (rather than status-code) branch of the classification against
+   * a real HTTP response.
+   *
+   * DEVIATION: see deviations.md "push: RSH3d2c1 - deregistration status
+   * classification unimplemented" — deactivate() REJECTS on the injected
+   * 40005 (observed against the sandbox: ErrorInfo code 40005, statusCode
+   * 400, message "invalid credentials") and rolls back instead of resolving.
+   */
+  // UTS: rest/proxy/RSH3d2c1/deregister-40005-classified-1
+  it('RSH3d2c1 - deregistration error code 40005 is classified as Deregistered without the DELETE reaching the server', async function () {
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+    session = await createProxySession();
+
+    const channelName = 'push-proxy-RSH3d2c1-40005-' + randomId();
+    const storage = seededStorage(ablyChannelRecipient(channelName));
+    const client = proxyPushClient(session, storage);
+    const admin = directAdminClient();
+
+    const deviceId = await activateThroughProxy(client, storage);
+
+    try {
+      await session.addRules([
+        {
+          match: { type: 'http_request', method: 'DELETE', pathContains: '/push/deviceRegistrations' },
+          action: {
+            type: 'http_respond',
+            status: 400,
+            body: { error: { message: 'invalid credentials', code: 40005, statusCode: 400 } },
+          },
+          times: 1,
+          comment: 'RSH3d2c1: answer the deregistration DELETE with 400/40005 without forwarding it',
+        },
+      ]);
+
+      // Resolves despite the 40005 — classified as Deregistered
+      await client.push.deactivate();
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'NotActivated', {
+        interval: 100,
+        timeout: 10000,
+      });
+
+      // RSH3g2a — local state cleared
+      const persisted = storage.dump();
+      expect(persisted).to.not.have.property('ably.push.deviceIdentityToken');
+      expect(persisted).to.not.have.property('ably.push.pushRecipient');
+
+      // The DELETE never reached the server: the registration STILL exists
+      const stillRegistered = await admin.push.admin.deviceRegistrations.get(deviceId);
+      expect(stillRegistered.id).to.equal(deviceId);
+    } finally {
+      // Best-effort cleanup of the orphaned server-side registration
+      await admin.push.admin.deviceRegistrations.remove(deviceId).catch(() => {});
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH3d2c1, RSH3g3b — deregistration failure fails deactivate and rolls
+  // back; the retry deregisters end-to-end
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH3d2c1, RSH3g3a, RSH3g3b - the first DELETE is answered with a
+   * synthetic 400/40198 (times: 1, not forwarded), so deactivate() fails and
+   * the machine rolls back — verified both locally (identity token survives)
+   * and server-side (registration still exists). The rule is then consumed,
+   * so a second deactivate() runs end-to-end against the real server: local
+   * state cleared AND the server-side registration gone.
+   *
+   * Note ably-js fires DeregistrationFailed on any DELETE error (see
+   * deviations.md "push: RSH3d2c1"), which for this NON-2xx/401/40005 fault
+   * happens to coincide with the conformant classification — so this test
+   * passes unadapted.
+   */
+  // UTS: rest/proxy/RSH3d2c1/deregister-failure-rollback-2
+  it('RSH3d2c1, RSH3g3b - deregistration failure fails deactivate and rolls back; the retry deregisters end-to-end', async function () {
+    session = await createProxySession();
+
+    const channelName = 'push-proxy-RSH3g3b-rollback-' + randomId();
+    const storage = seededStorage(ablyChannelRecipient(channelName));
+    const client = proxyPushClient(session, storage);
+    const admin = directAdminClient();
+
+    const deviceId = await activateThroughProxy(client, storage);
+
+    try {
+      await session.addRules([
+        {
+          match: { type: 'http_request', method: 'DELETE', pathContains: '/push/deviceRegistrations' },
+          action: {
+            type: 'http_respond',
+            status: 400,
+            body: { error: { message: 'deregistration rejected', code: 40198, statusCode: 400 } },
+          },
+          times: 1,
+          comment: 'RSH3g3b: fail only the first deregistration DELETE with a non-retriable 400/40198',
+        },
+      ]);
+
+      // RSH3g3a — deactivate returns with the error
+      let error: any;
+      try {
+        await client.push.deactivate();
+      } catch (err) {
+        error = err;
+      }
+      expect(error, 'deactivate() should have rejected with the injected error').to.exist;
+      expect(error.code).to.equal(40198);
+
+      // RSH3g3b — still registered locally: the identity token survives the rollback
+      expect(storage.dump()['ably.push.deviceIdentityToken']).to.exist;
+
+      // ... and server-side: the faulted DELETE was never forwarded
+      const stillRegistered = await admin.push.admin.deviceRegistrations.get(deviceId);
+      expect(stillRegistered.id).to.equal(deviceId);
+
+      // The rule is consumed — the retry deregisters end-to-end against the real server
+      await client.push.deactivate();
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'NotActivated', {
+        interval: 100,
+        timeout: 10000,
+      });
+
+      const persisted = storage.dump();
+      expect(persisted).to.not.have.property('ably.push.deviceIdentityToken');
+      expect(persisted).to.not.have.property('ably.push.pushRecipient');
+
+      // Server-side registration is gone
+      try {
+        await admin.push.admin.deviceRegistrations.get(deviceId);
+        expect.fail('deviceRegistrations.get should have failed after the successful deregistration');
+      } catch (err: any) {
+        expect(err.statusCode).to.equal(404);
+      }
+
+      // Two DELETEs were issued: the faulted one and the real one
+      const log = await session.getLog();
+      expect(registrationRequests(log, 'DELETE').length).to.equal(2);
+    } finally {
+      // Best-effort cleanup in case an assertion left the registration behind
+      await admin.push.admin.deviceRegistrations.remove(deviceId).catch(() => {});
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH3c3a — registration failure fails activate; the retry registers
+  // against the real server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH3c3a, RSH3c3b - the first registration POST is answered with a
+   * synthetic 500/50000 (times: 1), so activate() fails and the machine
+   * returns to NotActivated. This is necessarily early fault injection — the
+   * fault under test is the registration itself — but the retry then runs
+   * fully real, and a direct admin get confirms the registration exists
+   * server-side. endpoint: "localhost" disables fallback hosts (REC2c2) and
+   * none are configured, so the 500 produces exactly one POST attempt.
+   */
+  // UTS: rest/proxy/RSH3c3a/registration-failure-then-retry-0
+  it('RSH3c3a - registration failure fails activate; the retry registers against the real server', async function () {
+    session = await createProxySession({
+      rules: [
+        {
+          match: { type: 'http_request', method: 'POST', pathContains: '/push/deviceRegistrations' },
+          action: {
+            type: 'http_respond',
+            status: 500,
+            body: { error: { message: 'internal error', code: 50000, statusCode: 500 } },
+          },
+          times: 1,
+          comment: 'RSH3c3a: fail only the first registration POST with a synthetic 500/50000',
+        },
+      ],
+    });
+
+    const channelName = 'push-proxy-RSH3c3a-retry-' + randomId();
+    const storage = seededStorage(ablyChannelRecipient(channelName));
+    const client = proxyPushClient(session, storage);
+    const admin = directAdminClient();
+
+    let deviceId: string | undefined;
+    try {
+      // RSH3c3a — activate returns with the error
+      let error: any;
+      try {
+        await client.push.activate();
+      } catch (err) {
+        error = err;
+      }
+      expect(error, 'activate() should have rejected with the injected error').to.exist;
+      expect(error.code).to.equal(50000);
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'NotActivated', {
+        interval: 100,
+        timeout: 10000,
+      });
+
+      // RSH3c3b — from NotActivated the retry runs the full flow against the real server
+      await client.push.activate();
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails', {
+        interval: 100,
+        timeout: 10000,
+      });
+      deviceId = storage.dump()['ably.push.deviceId'];
+
+      // Server-side ground truth: the retry's registration reached the real server
+      const registered = await admin.push.admin.deviceRegistrations.get(deviceId);
+      expect(registered.id).to.equal(deviceId);
+
+      // Two POSTs were issued: the faulted one and the real one
+      const log = await session.getLog();
+      expect(registrationRequests(log, 'POST').length).to.equal(2);
+    } finally {
+      if (deviceId) {
+        await admin.push.admin.deviceRegistrations.remove(deviceId).catch(() => {});
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH4 — deactivate issued during an in-flight registration is queued, then
+  // deregisters after activation completes
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH4, RSH3c2b, RSH3d2 - the proxy holds the registration POST for 2s
+   * (well under the default httpRequestTimeout). Because the recipient is
+   * pre-seeded (RSH3a2c), activate() passes straight through to
+   * WaitingForDeviceRegistration with the POST in flight — and
+   * CalledDeactivate has NO defined transition there. Per RSH4 it queues: the
+   * activation resolves first when the delayed registration completes, then
+   * the dequeued CalledDeactivate deregisters against the real server. The
+   * proxy event log verifies the wire sequence: POST, then DELETE.
+   *
+   * ADAPTATION: the spec reads the registered device id from storage AFTER
+   * deactivation ("id/secret survive deactivation"). In ably-js they do not
+   * survive as-registered: the Deregistered handler calls device.resetId()
+   * (pushactivation.ts:866), which replaces the persisted
+   * deviceId/deviceSecret with fresh ulids. The registered id is captured
+   * from the seeded storage up front instead; all other assertions are per
+   * spec.
+   */
+  // UTS: rest/proxy/RSH4/deactivate-queued-behind-slow-registration-0
+  it('RSH4 - deactivate issued during an in-flight registration is queued, then deregisters after activation completes', async function () {
+    session = await createProxySession({
+      rules: [
+        {
+          match: { type: 'http_request', method: 'POST', pathContains: '/push/deviceRegistrations' },
+          action: { type: 'http_delay', delayMs: 2000 },
+          times: 1,
+          comment: 'RSH4: hold the registration POST for 2s so CalledDeactivate arrives in WaitingForDeviceRegistration',
+        },
+      ],
+    });
+
+    const channelName = 'push-proxy-RSH4-queued-' + randomId();
+    const storage = seededStorage(ablyChannelRecipient(channelName));
+    // Captured before any client ops — see the resetId ADAPTATION above.
+    const deviceId = storage.dump()['ably.push.deviceId'];
+    const client = proxyPushClient(session, storage);
+    const admin = directAdminClient();
+
+    try {
+      const resolutionOrder: string[] = [];
+      const activation = client.push.activate().then(() => {
+        resolutionOrder.push('activate');
+      });
+      // register a handler so a rejection before the await below is not
+      // reported as unhandled; the await still surfaces it
+      activation.catch(() => {});
+
+      // Wait until the registration POST is in flight (visible in the proxy
+      // event log while the http_delay holds it)
+      await pollUntil(
+        async () => {
+          const log = await session!.getLog();
+          return registrationRequests(log, 'POST').length === 1 || null;
+        },
+        { interval: 200, timeout: 10000 },
+      );
+
+      // CalledDeactivate: no transition defined in WaitingForDeviceRegistration → queued (RSH4)
+      const deactivation = client.push.deactivate().then(() => {
+        resolutionOrder.push('deactivate');
+      });
+      deactivation.catch(() => {});
+
+      await activation; // registration completes; activate resolves first (RSH3c2b)
+      await deactivation; // dequeued CalledDeactivate → RSH3d2 deregistration
+
+      // Activation resolved before deactivation
+      expect(resolutionOrder).to.deep.equal(['activate', 'deactivate']);
+
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'NotActivated', {
+        interval: 100,
+        timeout: 10000,
+      });
+      const persisted = storage.dump();
+      expect(persisted).to.not.have.property('ably.push.deviceIdentityToken');
+      expect(persisted).to.not.have.property('ably.push.pushRecipient');
+
+      // Server-side: the registration was created, then removed
+      try {
+        await admin.push.admin.deviceRegistrations.get(deviceId);
+        expect.fail('deviceRegistrations.get should have failed after the deregistration');
+      } catch (err: any) {
+        expect(err.statusCode).to.equal(404);
+      }
+
+      // Wire sequence: the registration POST strictly precedes the deregistration DELETE
+      const log = await session.getLog();
+      const regRequests = registrationRequests(log);
+      expect(regRequests.length).to.equal(2);
+      expect((regRequests[0].method ?? '').toUpperCase()).to.equal('POST');
+      expect((regRequests[1].method ?? '').toUpperCase()).to.equal('DELETE');
+    } finally {
+      await admin.push.admin.deviceRegistrations.remove(deviceId).catch(() => {});
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH3e3d, RSH3f1 — a failed registration sync is reported via the update
+  // callback; the next update syncs against the real server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH3e3d, RSH3e3b, RSH3f1 - an activated device receives a rotated token
+   * via updateToken. The proxy fails the resulting sync PATCH with a
+   * synthetic 400/40199 (times: 1): the fire-and-forget sync's failure must
+   * surface through the update callback (never through updateToken's return
+   * value), leaving the machine in AfterRegistrationSyncFailed. A second
+   * updateToken then finds the rule consumed and syncs end-to-end — verified
+   * by polling the direct admin get until the server-side recipient reflects
+   * the new token.
+   *
+   * ADAPTATION (per the spec's ably-js deviation note, RSH3e3d): the spec
+   * routes sync failures to the updatedCallback provided to Push#activate;
+   * ably-js delivers them to the deprecated updateFailedCallback (RSH3e3a) —
+   * activate()'s SECOND argument — instead. The retry sync is a PATCH
+   * (conformant).
+   *
+   * SKIPPED (server issue, fixed pending deploy): the second (real) sync
+   * PATCH targets a device whose stored recipient is ablyChannel, which the
+   * sandbox rejects (400, code 40000, "unknown transport type
+   * 'ablyChannel'") — see deviations.md "integration/push_activation:
+   * registration-update PATCH rejected for ablyChannel-recipient devices".
+   * The deviation adaptations above still apply once unskipped.
+   */
+  // UTS: rest/proxy/RSH3e3d/sync-failure-recovery-0
+  it('RSH3e3d, RSH3f1 - a failed registration sync is reported via the update callback; the next update syncs against the real server', async function () {
+    // SERVER ISSUE(ablyChannel PATCH): pending sandbox deploy of https://github.com/ably/realtime/pull/8591 — unskip once deployed
+    this.skip();
+
+    session = await createProxySession();
+
+    const channelName = 'push-proxy-RSH3e3d-sync-' + randomId();
+    const storage = seededStorage(ablyChannelRecipient(channelName));
+    const client = proxyPushClient(session, storage);
+    const admin = directAdminClient();
+
+    const updatedResults: any[] = [];
+    // updateFailedCallback is activate()'s second argument — see ADAPTATION above
+    await client.push.activate(undefined, (err: any) => updatedResults.push(err));
+    await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails', {
+      interval: 100,
+      timeout: 10000,
+    });
+    const deviceId = storage.dump()['ably.push.deviceId'];
+
+    try {
+      // Late fault injection: fail only the first sync PATCH
+      await session.addRules([
+        {
+          match: { type: 'http_request', method: 'PATCH', pathContains: '/push/deviceRegistrations' },
+          action: {
+            type: 'http_respond',
+            status: 400,
+            body: { error: { message: 'sync rejected', code: 40199, statusCode: 400 } },
+          },
+          times: 1,
+          comment: 'RSH3e3d: fail only the first token-rotation sync PATCH with 400/40199',
+        },
+      ]);
+
+      // updateToken resolves (the sync is fire-and-forget) ...
+      await client.push.updateToken({ transportType: 'fcm', token: 'proxy-fcm-token-2' });
+
+      // ... and the sync failure surfaces via the update callback (RSH3e3d)
+      await pollUntil(() => updatedResults.length === 1 || null, { interval: 100, timeout: 10000 });
+      expect(updatedResults[0]).to.exist;
+      expect(updatedResults[0].code).to.equal(40199);
+
+      // RSH3e3b — the machine is in AfterRegistrationSyncFailed.
+      // DEVIATION: see deviations.md "push: AfterRegistrationSyncFailed not
+      // persisted" — only NotActivated and WaitingForNewPushDeviceDetails are
+      // persistent in ably-js (isPersistentState, pushactivation.ts:896), so
+      // the persisted state still reads WaitingForNewPushDeviceDetails even
+      // though the in-memory machine is in AfterRegistrationSyncFailed.
+      if (process.env.RUN_DEVIATIONS) {
+        await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'AfterRegistrationSyncFailed', {
+          interval: 100,
+          timeout: 10000,
+        });
+      } else {
+        expect(storage.dump()['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
+      }
+
+      // RSH3f1 — the next GotPushDeviceDetails re-runs the sync; the rule is
+      // consumed, so the PATCH reaches the real server
+      await client.push.updateToken({ transportType: 'fcm', token: 'proxy-fcm-token-3' });
+
+      // Server-side ground truth: poll the direct admin get until the
+      // recipient reflects the new token
+      await pollUntil(
+        async () => {
+          const device = await admin.push.admin.deviceRegistrations.get(deviceId);
+          const recipient = device.push?.recipient as any;
+          return (
+            (recipient?.transportType === 'fcm' && recipient?.registrationToken === 'proxy-fcm-token-3') || null
+          );
+        },
+        { interval: 500, timeout: 15000 },
+      );
+
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails', {
+        interval: 100,
+        timeout: 10000,
+      });
+
+      // Two PATCHes were issued: the faulted one and the real one
+      const log = await session.getLog();
+      expect(registrationRequests(log, 'PATCH').length).to.equal(2);
+    } finally {
+      await admin.push.admin.deviceRegistrations.remove(deviceId).catch(() => {});
+    }
+  });
+});

--- a/test/uts/rest/integration/push_activation.test.ts
+++ b/test/uts/rest/integration/push_activation.test.ts
@@ -1,0 +1,484 @@
+/**
+ * UTS Integration: Push Activation Tests
+ *
+ * Spec points: RSH1a, RSH2a, RSH2b, RSH2f, RSH3a2a3, RSH3a2c, RSH3b3c, RSH6a, RSH8a, RSH8c
+ * Source: uts/rest/integration/push_activation.md
+ *
+ * These tests drive the real push activation state machine (via the
+ * ReactNativePush plugin carrying a MockPushStorage) against the Ably
+ * sandbox. Per the spec's seeded-ablyChannel-recipient design, storage is
+ * pre-seeded with an `ablyChannel` push recipient so `requestToken` is never
+ * consulted (RSH3a2c) and the registration/sync/deregistration requests and
+ * push delivery are exercised end to end against the real server.
+ */
+
+import { expect } from 'chai';
+import {
+  Ably,
+  SANDBOX_ENDPOINT,
+  setupSandbox,
+  teardownSandbox,
+  getApiKey,
+  pollUntil,
+  pollUntilSuccess,
+} from './sandbox';
+import { MockPushStorage, installReactNativeFake, restoreReactNativeFake } from '../unit/push/push_helpers';
+import ReactNativePush from '../../../../src/plugins/react-native-push';
+
+const SANDBOX_REST_URL = 'https://sandbox.realtime.ably-nonprod.net';
+
+function randomId(): string {
+  return Math.random().toString(36).substring(2, 10);
+}
+
+/**
+ * UTS `seeded_storage(recipient_channel)`: storage pre-seeded with an
+ * ablyChannel recipient — a first-ever activation with known push details.
+ *
+ * DEVIATION (RSH8a): the spec seeds only ably.push.pushRecipient — a partial
+ * persisted state implementations must tolerate ("to the extent that they
+ * exist"). ably-js does not: LocalDevice.loadPersistedAsync() reads
+ * pushRecipient only when ably.push.deviceId is present in storage
+ * (src/plugins/push/pushactivation.ts:196-206; the no-id branch calls
+ * resetId() and never reads the recipient key), so activate() over a
+ * recipient-only seed falls through to requestToken and rejects with
+ * "Failed to get react-native push device details: requestToken must not be
+ * called: recipient is pre-seeded (RSH3a2c)" (verified against the sandbox).
+ * Adapted by also seeding deviceId/deviceSecret (their eager generation is
+ * sanctioned by the spec's RSH8k2 note); the seeded-recipient design and all
+ * server interactions are otherwise unchanged.
+ */
+function seededStorage(recipientChannel: string): MockPushStorage {
+  const storage = new MockPushStorage();
+  storage.seed({
+    'ably.push.pushRecipient': JSON.stringify({
+      transportType: 'ablyChannel',
+      channel: recipientChannel,
+      ablyKey: getApiKey(0),
+      ablyUrl: SANDBOX_REST_URL,
+    }),
+    'ably.push.deviceId': 'uts-device-' + randomId(),
+    'ably.push.deviceSecret': 'uts-secret-' + randomId() + randomId(),
+  });
+  return storage;
+}
+
+/**
+ * UTS `push_client(storage, key?)`: real HTTP against the sandbox; only the
+ * push platform (storage + requestToken) is mocked, via the ReactNativePush
+ * plugin (ably-js's per-client push platform injection seam). Per RSH3a2c the
+ * seeded recipient means requestToken must never be consulted.
+ */
+function pushClient(storage: MockPushStorage, key?: string): any {
+  const plugin = ReactNativePush.create({
+    storage,
+    requestToken: async () => {
+      throw new Error('requestToken must not be called: recipient is pre-seeded (RSH3a2c)');
+    },
+  });
+  return new Ably.Rest({
+    key: key ?? getApiKey(0),
+    endpoint: SANDBOX_ENDPOINT,
+    useBinaryProtocol: false,
+    plugins: { Push: plugin },
+  } as any);
+}
+
+/** UTS `admin_client()`: separate client for server-side verification. */
+function adminClient(): any {
+  return new Ably.Rest({
+    key: getApiKey(0),
+    endpoint: SANDBOX_ENDPOINT,
+    useBinaryProtocol: false,
+  });
+}
+
+describe('uts/rest/integration/push_activation', function () {
+  this.timeout(120000);
+
+  before(async function () {
+    // The ReactNativePush plugin resolves require('react-native').Platform.OS
+    // inside create(); fake the module for the whole suite (platform: android).
+    installReactNativeFake();
+    await setupSandbox();
+  });
+
+  after(async function () {
+    restoreReactNativeFake();
+    await teardownSandbox();
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH2a — activate registers the device with the real server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH2a, RSH3a2c, RSH3b3b, RSH8c - full happy-path activation round-trip:
+   * the seeded ablyChannel recipient is registered via POST
+   * /push/deviceRegistrations, the server grants a deviceIdentityToken, and
+   * the registration is visible through the admin API.
+   */
+  // UTS: rest/integration/RSH2a/activate-registers-device-0
+  it('RSH2a - activate registers the device with the real server', async function () {
+    const recipientChannel = 'push-recipient-RSH2a-' + randomId();
+    const storage = seededStorage(recipientChannel);
+    const client = pushClient(storage);
+    const admin = adminClient();
+    let deviceId: string | undefined;
+
+    try {
+      await client.push.activate();
+
+      // ADAPTATION: the spec reads client.device(); with the ReactNativePush
+      // plugin storage is asynchronous, so ably-js requires await client.getDevice().
+      const device = await client.getDevice();
+      deviceId = device.id;
+      expect(device.id).to.be.a('string').and.not.be.empty;
+      expect(device.deviceIdentityToken).to.be.a('string').and.not.be.empty;
+
+      // Persistence settles fire-and-forget after activate resolves
+      await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails', {
+        interval: 100,
+        timeout: 10000,
+      });
+
+      // Server-side verification via a separate admin client
+      const registration = await admin.push.admin.deviceRegistrations.get(device.id);
+      expect(registration.id).to.equal(device.id);
+      expect(registration.platform).to.equal('android');
+      expect(registration.formFactor).to.equal('phone');
+      expect((registration.push!.recipient as any).transportType).to.equal('ablyChannel');
+      expect((registration.push!.recipient as any).channel).to.equal(recipientChannel);
+    } finally {
+      if (deviceId) {
+        await admin.push.admin.deviceRegistrations.remove(deviceId);
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH8c, RSH6a — persisted deviceIdentityToken is usable by a fresh client
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH8c, RSH8a, RSH6a - the identity token granted at registration
+   * round-trips through storage: a fresh client over the same storage, using
+   * the restricted push_subscribe_key (keys[1]), performs a device-authenticated
+   * channel.push.subscribeDevice() without calling activate() and without
+   * re-registering. The push-subscribe capability authorizes subscribing only
+   * the authenticated device, so this succeeds only if the server accepts the
+   * SDK's device authentication.
+   *
+   * FINDING (RSH6a raw-token open question): ably-js's subscribeDevice sends
+   * `X-Ably-DeviceToken: <raw deviceIdentityToken>` (src/plugins/push/
+   * pushchannel.ts:130 — LocalDevice.deviceIdentityToken holds the raw token
+   * string, set from tokenDetails.token at pushactivation.ts:776; no base64,
+   * no Authorization bearer), alongside normal basic key auth. Verified by
+   * direct probing with a push-subscribe-only key: the sandbox accepts the
+   * RAW token (201), and ALSO accepts a base64-encoded token (201) — so both
+   * the spec's raw form and ably-java/ably-cocoa's base64 form work; without
+   * the header the same request is rejected 401/40160 "action not permitted"
+   * (proving the subscription is authorized by device auth, not the key), and
+   * `Authorization: Bearer base64(token)` in place of key auth is rejected
+   * 401/40160.
+   */
+  // UTS: rest/integration/RSH8c/identity-token-usable-0
+  it('RSH8c, RSH6a - persisted deviceIdentityToken is usable by a fresh client', async function () {
+    const recipientChannel = 'push-recipient-RSH8c-' + randomId();
+    const storage = seededStorage(recipientChannel);
+    const admin = adminClient();
+    const channelName = 'pushenabled:test-RSH8c-' + randomId();
+    let deviceId: string | undefined;
+    let subscribed = false;
+
+    try {
+      // First app run: register the device
+      const client1 = pushClient(storage);
+      await client1.push.activate();
+      deviceId = (await client1.getDevice()).id;
+
+      // Second app run: fresh client over the same storage, restricted key.
+      // No activate() call — the LocalDevice must hydrate from storage (RSH8a).
+      const client2 = pushClient(storage, getApiKey(1));
+      const channel = client2.channels.get(channelName);
+      await channel.push.subscribeDevice();
+      subscribed = true;
+
+      const device2 = await client2.getDevice();
+      expect(device2.id).to.equal(deviceId);
+      expect(device2.deviceIdentityToken).to.be.a('string').and.not.be.empty;
+
+      // Server-side verification: the subscription exists
+      const result = await admin.push.admin.channelSubscriptions.list({
+        channel: channelName,
+        deviceId,
+      });
+      expect(result.items).to.have.length(1);
+      expect((result.items[0] as any).deviceId).to.equal(deviceId);
+      expect((result.items[0] as any).channel).to.equal(channelName);
+    } finally {
+      if (subscribed) {
+        await admin.push.admin.channelSubscriptions.remove({ channel: channelName, deviceId });
+      }
+      if (deviceId) {
+        await admin.push.admin.deviceRegistrations.remove(deviceId);
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH2b — deactivate deregisters the device from the real server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH2b, RSH3g3a - after deactivate() resolves, the registration no longer
+   * exists server-side (admin get reports 404). Note ably-js's deregistration
+   * DELETE adds `authorization: Bearer base64(deviceIdentityToken)`
+   * (pushactivation.ts:253), not X-Ably-DeviceToken — see deviations.md
+   * "push: RSH6a/RSH6b/RSH3d2b". This test's full-access key authorizes the
+   * DELETE by itself, so the bearer device auth is not isolated here (probing
+   * shows bearer alone, without key auth, is rejected 401/40160).
+   */
+  // UTS: rest/integration/RSH2b/deactivate-deregisters-0
+  it('RSH2b - deactivate deregisters the device from the real server', async function () {
+    const recipientChannel = 'push-recipient-RSH2b-' + randomId();
+    const storage = seededStorage(recipientChannel);
+    const client = pushClient(storage);
+    const admin = adminClient();
+
+    await client.push.activate();
+    const deviceId = (await client.getDevice()).id;
+
+    // Confirm the registration exists before deactivating
+    await admin.push.admin.deviceRegistrations.get(deviceId);
+
+    await client.push.deactivate();
+
+    try {
+      await admin.push.admin.deviceRegistrations.get(deviceId);
+      expect.fail('deviceRegistrations.get should have failed after deactivate');
+    } catch (error: any) {
+      expect(error.statusCode).to.equal(404);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH3a2a3 — reactivation over registered state syncs against the real server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH3a2a3, RSH3a2a - a second app run's activate() over already-registered
+   * state resolves and the server-side registration survives intact.
+   *
+   * DEVIATION (deviations.md "push: RSH3a2a/RSH3f1 - re-activation registration
+   * sync not implemented"): ably-js performs NO re-activation registration sync —
+   * NotActivated + CalledActivate with a registered device re-queues into
+   * WaitingForNewPushDeviceDetails, which resolves activate() immediately
+   * without contacting the server. The RSH3d3b PATCH is therefore not
+   * exercised here; the behavioural assertions below (activate resolves, the
+   * registration is unchanged server-side) pass trivially.
+   */
+  // UTS: rest/integration/RSH3a2a3/reactivation-validates-0
+  it('RSH3a2a3 - reactivation over registered state syncs against the real server', async function () {
+    const recipientChannel = 'push-recipient-RSH3a2a3-' + randomId();
+    const storage = seededStorage(recipientChannel);
+    const admin = adminClient();
+    let deviceId: string | undefined;
+
+    try {
+      // First app run: register the device
+      const client1 = pushClient(storage);
+      await client1.push.activate();
+      deviceId = (await client1.getDevice()).id;
+
+      // Second app run: fresh client over the same storage
+      const client2 = pushClient(storage);
+      await client2.push.activate();
+
+      const device2 = await client2.getDevice();
+      expect(device2.id).to.equal(deviceId);
+      expect(device2.deviceIdentityToken).to.be.a('string').and.not.be.empty;
+
+      const registration = await admin.push.admin.deviceRegistrations.get(deviceId);
+      expect(registration.id).to.equal(deviceId);
+      expect((registration.push!.recipient as any).transportType).to.equal('ablyChannel');
+      expect((registration.push!.recipient as any).channel).to.equal(recipientChannel);
+    } finally {
+      if (deviceId) {
+        await admin.push.admin.deviceRegistrations.remove(deviceId);
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH1a — direct publish to the activated device is received end to end
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH1a - push.admin.publish({deviceId}, data) delivers a push notification
+   * to the registered ablyChannel recipient: the sandbox delivers it as an
+   * `__ably_push__` message on the recipient channel, with the push payload
+   * JSON-encoded as a string in the message data.
+   */
+  // UTS: rest/integration/RSH1a/direct-publish-received-0
+  it('RSH1a - direct publish to the activated device is received end to end', async function () {
+    const recipientChannel = 'push-recipient-RSH1a-' + randomId();
+    const storage = seededStorage(recipientChannel);
+    const client = pushClient(storage);
+    const admin = adminClient();
+    let deviceId: string | undefined;
+    let realtime: any;
+
+    try {
+      await client.push.activate();
+      deviceId = (await client.getDevice()).id;
+
+      // A realtime client subscribed to the recipient channel receives the push
+      realtime = new Ably.Realtime({
+        key: getApiKey(0),
+        endpoint: SANDBOX_ENDPOINT,
+        useBinaryProtocol: false,
+      });
+      const rtChannel = realtime.channels.get(recipientChannel);
+      const received: any[] = [];
+      await rtChannel.subscribe('__ably_push__', (msg: any) => received.push(msg));
+
+      const pushPayload = {
+        notification: { title: 'Integration Test', body: 'Push activation e2e' },
+        data: { foo: 'bar' },
+      };
+
+      await admin.push.admin.publish({ deviceId }, pushPayload);
+
+      const msg = await pollUntil(() => (received.length >= 1 ? received[0] : null), {
+        interval: 100,
+        timeout: 15000,
+      });
+
+      expect(msg.name).to.equal('__ably_push__');
+      const receivedPayload = JSON.parse(msg.data);
+      expect(receivedPayload.notification.title).to.equal('Integration Test');
+      expect(receivedPayload.notification.body).to.equal('Push activation e2e');
+      expect(receivedPayload.data).to.deep.equal({ foo: 'bar' });
+    } finally {
+      if (realtime) {
+        realtime.close();
+      }
+      if (deviceId) {
+        await admin.push.admin.deviceRegistrations.remove(deviceId);
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH3b3c — registration rejected by the server fails activation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH3b3c, RSH3b4a - a registration the real server rejects (invalid
+   * platform) surfaces the server's error through activate(), and the machine
+   * settles back in NotActivated.
+   *
+   * ADAPTATION: the spec injects the invalid platform via the platform config
+   * (push_client(storage, platform: "not_a_real_platform")); ably-js's
+   * ReactNativePush plugin maps react-native Platform.OS onto only
+   * ios/android, so an arbitrary platform cannot be injected there. Instead
+   * the hydrated LocalDevice's platform is mutated directly before activate(),
+   * mirroring ably-js's own failed_registration test (test/rest/push.test.js).
+   */
+  // UTS: rest/integration/RSH3b3c/registration-failure-invalid-platform-0
+  it('RSH3b3c - registration rejected by the server fails activation', async function () {
+    const recipientChannel = 'push-recipient-RSH3b3c-' + randomId();
+    const storage = seededStorage(recipientChannel);
+    const client = pushClient(storage);
+
+    const device = await client.getDevice();
+    device.platform = 'not_a_real_platform';
+
+    let error: any;
+    try {
+      await client.push.activate();
+    } catch (err) {
+      error = err;
+    }
+    expect(error, 'activate() should have rejected with the server error').to.exist;
+    expect(error.statusCode).to.be.at.least(400).and.below(500);
+
+    // The machine settles back in NotActivated
+    await pollUntilSuccess(() => storage.dump()['ably.push.activationState'] === 'NotActivated', {
+      interval: 100,
+      timeout: 10000,
+    });
+
+    expect((await client.getDevice()).deviceIdentityToken).to.not.exist;
+  });
+
+  // ---------------------------------------------------------------------------
+  // RSH2f — updateToken's fire-and-forget sync is accepted by the real server
+  // ---------------------------------------------------------------------------
+
+  /**
+   * RSH2f, RSH3d3b - on an activated device, updateToken resolves and the
+   * fire-and-forget PATCH sync (carrying the new fcm push.recipient) lands
+   * server-side: the admin API eventually shows the new recipient. Per the
+   * spec's isolation notes this test replaces the device's ablyChannel
+   * recipient with an fcm one (the rotated token is necessarily fcm — RSH2f1
+   * accepts only fcm/apns), after which the device can no longer receive
+   * ablyChannel deliveries — so it uses its own storage, device and channel.
+   *
+   * A sync rejection would surface via updateFailedCallback (activate's 2nd
+   * arg), never through the updateToken() promise — captured below so the
+   * server's actual response is reported precisely.
+   *
+   * SKIPPED (server issue, fixed pending deploy): see deviations.md
+   * "integration/push_activation: registration-update PATCH rejected for
+   * ablyChannel-recipient devices" — the sandbox rejects the sync PATCH for
+   * any device whose stored recipient is ablyChannel (400, code 40000,
+   * "unknown transport type 'ablyChannel'").
+   */
+  // UTS: rest/integration/RSH2f/update-token-synced-0
+  it('RSH2f - updateToken fire-and-forget sync is accepted by the real server', async function () {
+    // SERVER ISSUE(ablyChannel PATCH): pending sandbox deploy of https://github.com/ably/realtime/pull/8591 — unskip once deployed
+    this.skip();
+
+    const recipientChannel = 'push-recipient-RSH2f-' + randomId();
+    const storage = seededStorage(recipientChannel);
+    const client = pushClient(storage);
+    const admin = adminClient();
+    let deviceId: string | undefined;
+    const syncFailures: any[] = [];
+
+    try {
+      // updateToken sync failures surface via updateFailedCallback, not the
+      // activate()/updateToken() promises — capture them for diagnosis.
+      await client.push.activate(undefined, (err: any) => syncFailures.push(err));
+      deviceId = (await client.getDevice()).id;
+      const newToken = 'fake-fcm-token-' + randomId();
+
+      await client.push.updateToken({ transportType: 'fcm', token: newToken });
+
+      // The sync is fire-and-forget: poll the admin API until the PATCH lands
+      const registration: any = await pollUntil(
+        async () => {
+          if (syncFailures.length > 0) {
+            throw new Error(
+              'updateToken registration sync failed (server rejected the PATCH): ' +
+                JSON.stringify(syncFailures[0], Object.getOwnPropertyNames(syncFailures[0] ?? {})),
+            );
+          }
+          const reg = await admin.push.admin.deviceRegistrations.get(deviceId);
+          return (reg.push?.recipient as any)?.transportType === 'fcm' ? reg : null;
+        },
+        { interval: 500, timeout: 20000 },
+      );
+
+      expect(registration.id).to.equal(deviceId);
+      expect((registration.push!.recipient as any).transportType).to.equal('fcm');
+      expect((registration.push!.recipient as any).registrationToken).to.equal(newToken);
+    } finally {
+      if (deviceId) {
+        await admin.push.admin.deviceRegistrations.remove(deviceId);
+      }
+    }
+  });
+});

--- a/test/uts/rest/unit/push/local_device.test.ts
+++ b/test/uts/rest/unit/push/local_device.test.ts
@@ -1,0 +1,233 @@
+/**
+ * UTS: LocalDevice Tests
+ *
+ * Spec points: RSH8, RSH8a, RSH8d, RSH8e, RSH8f, RSH8k, RSH8k1, RSH8k2
+ * Source: uts/rest/unit/push/local_device.md
+ *
+ * The device accessor (RSH8) and the LocalDevice attributes: population after a
+ * full activation (RSH8k/RSH8k1/RSH8k2), pure load from persisted state (RSH8a),
+ * clientId adoption from the registration response (RSH8f), and the late-identified
+ * client flow (RSH8d/RSH8e).
+ *
+ * Per the spec's Notes, `AWAIT client.device()` maps to ably-js's async
+ * `await client.getDevice()` (push storage is asynchronous in the React Native
+ * plugin; the sync `device()` throws pre-hydration).
+ */
+
+import { expect } from 'chai';
+import { restoreAll } from '../../../helpers';
+import {
+  MockPushStorage,
+  mockRegistrationServer,
+  pushClient,
+  activateInto,
+  waitFor,
+  installReactNativeFake,
+  restoreReactNativeFake,
+} from './push_helpers';
+
+/**
+ * UTS `late_identified_client(storage)`: a client using token auth via authCallback,
+ * so that its identity can change after construction (RSA7b2/RSA7b3): the first token
+ * is anonymous, every later token is identified as "alice". No HTTP is involved — the
+ * callback returns TokenDetails directly (RSA8d).
+ *
+ * The TokenDetails carry `issued`/`expires`: ably-js's requestToken() classifies the
+ * callback result as TokenDetails by the presence of an `issued` field (auth.ts), and
+ * without `expires` a token older than a minute would be discarded as expired.
+ */
+function lateIdentifiedClient(storage: MockPushStorage): any {
+  let authCalls = 0;
+  return pushClient(storage, {
+    clientOptions: {
+      authCallback: (_tokenParams: any, callback: (err: any, tokenDetails: any) => void) => {
+        authCalls += 1;
+        const validity = { issued: Date.now(), expires: Date.now() + 60 * 60 * 1000 };
+        if (authCalls === 1) {
+          callback(null, { token: 'anon-token-1', ...validity });
+        } else {
+          callback(null, { token: 'alice-token-1', clientId: 'alice', ...validity });
+        }
+      },
+    },
+  });
+}
+
+describe('uts/rest/unit/push/local_device', function () {
+  before(function () {
+    installReactNativeFake();
+  });
+
+  after(function () {
+    restoreReactNativeFake();
+  });
+
+  afterEach(function () {
+    restoreAll();
+  });
+
+  // UTS: rest/unit/RSH8/device-returns-local-device-0
+  it('RSH8 - the device accessor returns the activated LocalDevice', async function () {
+    mockRegistrationServer();
+    const storage = new MockPushStorage();
+    const client = await activateInto(storage);
+
+    const device = await client.getDevice();
+
+    const persisted = storage.dump();
+    expect(device.id).to.equal(persisted['ably.push.deviceId']);
+    expect(device.deviceSecret).to.exist; // RSH8k2
+    expect(device.deviceIdentityToken).to.equal('ident-token-1'); // RSH8k1
+    expect(device.platform).to.equal('android');
+    expect(device.formFactor).to.equal('phone');
+    expect(device.push.recipient).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-1',
+    });
+  });
+
+  // UTS: rest/unit/RSH8a/device-populated-from-persisted-state-0
+  it('RSH8a - LocalDevice is populated from persisted state without any request', async function () {
+    const capturedRequests = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    await activateInto(storage); // client1: register and persist
+    const persisted = storage.dump();
+
+    // A fresh client over the same storage simulates an app restart
+    const client2 = pushClient(storage);
+    const requestsBefore = capturedRequests.length;
+    const device = await client2.getDevice();
+
+    expect(device.id).to.equal(persisted['ably.push.deviceId']);
+    expect(device.deviceSecret).to.equal(persisted['ably.push.deviceSecret']);
+    expect(device.deviceIdentityToken).to.equal('ident-token-1');
+    expect(device.push.recipient).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-1',
+    });
+
+    // The device accessor made no HTTP request of its own
+    expect(capturedRequests.length).to.equal(requestsBefore);
+  });
+
+  // UTS: rest/unit/RSH8k1/device-identity-token-null-before-registration-0
+  it('RSH8k1 - deviceIdentityToken is null before registration', async function () {
+    mockRegistrationServer();
+    const storage = new MockPushStorage();
+    const client = pushClient(storage);
+
+    const device = await client.getDevice();
+
+    expect(device.deviceIdentityToken).to.not.exist;
+    // Deliberately no assertion on device.id / device.deviceSecret — see spec Notes
+  });
+
+  // UTS: rest/unit/RSH8f/clientid-from-registration-response-0
+  it('RSH8f - clientId from the registration response is set on the LocalDevice', async function () {
+    // DEVIATION(RSH8f): ably-js does not apply a clientId returned in the registration
+    // response to the LocalDevice — GotDeviceRegistration captures only the
+    // deviceIdentityToken from the response body (src/plugins/push/pushactivation.ts),
+    // so device.clientId remains unset.
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    mockRegistrationServer((req) => {
+      if (req.method === 'post' && req.path === '/push/deviceRegistrations') {
+        req.respond_with(201, {
+          ...JSON.parse(req.body),
+          deviceIdentityToken: { token: 'ident-token-1' },
+          clientId: 'client-from-server',
+        });
+        return true;
+      }
+      return false;
+    });
+    const storage = new MockPushStorage();
+    const client = pushClient(storage); // no clientId — unidentified (RSA7)
+
+    await client.push.activate();
+    const device = await client.getDevice();
+
+    expect(device.clientId).to.equal('client-from-server');
+  });
+
+  // UTS: rest/unit/RSH8d/late-clientid-persisted-0
+  it('RSH8d - a clientId acquired after registration is set and persisted', async function () {
+    // DEVIATION(RSH8d): ably-js has no late-identification plumbing — it does not derive
+    // auth.clientId from TokenDetails at all (ably-js issue #2192), and there is no hook
+    // from auth into the LocalDevice, so the clientId is never set or persisted.
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    mockRegistrationServer();
+    const storage = new MockPushStorage();
+    const client = lateIdentifiedClient(storage);
+
+    await client.push.activate();
+    const device = await client.getDevice();
+    expect(device.deviceIdentityToken).to.equal('ident-token-1');
+    expect(device.clientId).to.not.exist; // registered while unidentified
+
+    // The client becomes identified: the second token carries clientId "alice" (RSA7b2)
+    const tokenDetails = await client.auth.authorize();
+    expect(tokenDetails.clientId).to.equal('alice');
+
+    // RSH8d — the LocalDevice clientId is set...
+    await waitFor(() => device.clientId === 'alice', 'the LocalDevice clientId to be set');
+
+    // ...and persisted: a fresh client over the same storage sees it (polled, because
+    // persistence may settle asynchronously after the clientId is set)
+    let device2: any = null;
+    for (let i = 0; i < 50 && !device2; i++) {
+      const d = await pushClient(storage).getDevice();
+      if (d.clientId === 'alice') {
+        device2 = d;
+      }
+    }
+    if (!device2) {
+      throw new Error('timed out waiting for the persisted clientId to be visible to a fresh client');
+    }
+    expect(device2.id).to.equal(device.id);
+    expect(device2.clientId).to.equal('alice');
+  });
+
+  // UTS: rest/unit/RSH8e/late-clientid-triggers-sync-0
+  it('RSH8e - a late clientId on a registered device triggers a registration sync', async function () {
+    // DEVIATION(RSH8e): depends on the RSH8d late-identification plumbing, which ably-js
+    // lacks (issue #2192) — no GotPushDeviceDetails event is ever fired on late
+    // identification, so no registration sync PATCH is made.
+    // Note also DEVIATION(device-auth-header): were the sync to happen, ably-js
+    // authenticates device-authenticated requests with an `authorization: Bearer
+    // base64(deviceIdentityToken)` header rather than the RSH6a X-Ably-DeviceToken
+    // header asserted below (see the spec's Notes on device authentication).
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const capturedRequests = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    const client = lateIdentifiedClient(storage);
+
+    await client.push.activate(); // registered; machine in WaitingForNewPushDeviceDetails
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+    const deviceId = storage.dump()['ably.push.deviceId'];
+
+    await client.auth.authorize(); // client becomes identified as "alice" (RSA7b2), RSH8d sets clientId
+
+    // RSH8e — GotPushDeviceDetails is sent once the clientId is set, observable
+    // as the RSH3d3b registration sync
+    await waitFor(() => capturedRequests.some((req) => req.method === 'patch'), 'the RSH3d3b registration sync PATCH');
+    const patch = capturedRequests.filter((req) => req.method === 'patch')[0];
+
+    expect(patch.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+
+    // RSH3d3b + RSH6a — push device authentication
+    expect(patch.headers['X-Ably-DeviceToken']).to.equal('ident-token-1');
+
+    // The sync completes and the machine settles back into WaitingForNewPushDeviceDetails
+    // (RSH3d3d -> WaitingForRegistrationSync, then RegistrationSynced -> RSH3e2a)
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'the machine to settle back into WaitingForNewPushDeviceDetails',
+    );
+  });
+});

--- a/test/uts/rest/unit/push/push_activation_event_queue.test.ts
+++ b/test/uts/rest/unit/push/push_activation_event_queue.test.ts
@@ -1,0 +1,203 @@
+/**
+ * UTS: Push Activation Event Queue Tests
+ *
+ * Exercises the Activation State Machine's pending-event queue (RSH4) and its atomic,
+ * sequential event handling (RSH5), black-box: events are produced by driving the public
+ * API (push.activate()/push.deactivate()), the mocked requestToken, and by responding to
+ * (or holding) the mocked HTTP requests the machine issues.
+ *
+ * Spec points: RSH3a2a3, RSH3a2a4, RSH3a2b, RSH3a2d, RSH3a2e, RSH3a3a, RSH3b2a, RSH3b2b,
+ *   RSH3b3b, RSH3c2b, RSH3d1a, RSH3e1, RSH3e2a, RSH3e2b, RSH3g2a, RSH3g2b, RSH3g2c, RSH4, RSH5
+ * Source: specification/uts/rest/unit/push/push_activation_event_queue.md
+ */
+
+import { expect } from 'chai';
+import { restoreAll } from '../../../helpers';
+import type { ReactNativePushToken } from '../../../../../src/plugins/react-native-push';
+import {
+  installReactNativeFake,
+  restoreReactNativeFake,
+  MockPushStorage,
+  mockRegistrationServer,
+  pushClient,
+  activateInto,
+  waitFor,
+  flush,
+  deferred,
+} from './push_helpers';
+
+describe('uts/rest/unit/push/push_activation_event_queue', function () {
+  before(function () {
+    installReactNativeFake();
+  });
+
+  after(function () {
+    restoreReactNativeFake();
+  });
+
+  afterEach(function () {
+    restoreAll();
+  });
+
+  /**
+   * RSH4 — the spec's own worked example, driven black-box: with the deregistration DELETE
+   * held open, an activate() produces a CalledActivate with no defined transition in
+   * WaitingForDeregistration, so the event queues (no new request while held). Releasing the
+   * DELETE lands the machine in NotActivated (RSH3g2c), where the queued event is consumed
+   * and the full registration flow re-runs against a NEW device identity (RSH3g2a cleared
+   * the old one; RSH3a2b/RSH3a2d regenerate it).
+   */
+  // UTS: rest/unit/RSH4/activate-queued-during-deregistration-0
+  it('RSH4 - activate queued during deregistration is consumed after it and re-registers a new device', async function () {
+    let heldDelete: any = null;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'delete' && !heldDelete) {
+        heldDelete = req; // hold the deregistration open
+        return true;
+      }
+      return false;
+    });
+    const storage = new MockPushStorage();
+
+    let tokenRequests = 0;
+    const client = pushClient(storage, {
+      requestToken: async () => {
+        tokenRequests += 1;
+        return { transportType: 'fcm', token: 'fcm-token-1' } as ReactNativePushToken;
+      },
+    });
+    await client.push.activate();
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+
+    const deactivation = client.push.deactivate(undefined as any);
+    await waitFor(() => !!heldDelete, 'the deregistration DELETE');
+
+    // No transition defined for CalledActivate in WaitingForDeregistration: it queues (RSH4)
+    const activation = client.push.activate();
+    await flush();
+    expect(captured).to.have.length(2); // activation POST + held DELETE; nothing new while queued
+
+    heldDelete.respond_with(204, '');
+
+    await deactivation; // RSH3g2b
+    await activation; // RSH3c2b — resolves after the dequeued event's full re-registration
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'the re-registration to settle in WaitingForNewPushDeviceDetails',
+    );
+
+    // RSH3a2d — the platform token was requested again for the re-registration
+    expect(tokenRequests).to.equal(2);
+
+    // RSH3b3b — a second registration POST ran after the deregistration
+    const posts = captured.filter((req) => req.method === 'post');
+    expect(posts).to.have.length(2);
+
+    // RSH3g2a + RSH3a2b — the old device was cleared, so a NEW deviceId was registered
+    const firstId = JSON.parse(posts[0].body).id;
+    const secondId = JSON.parse(posts[1].body).id;
+    expect(secondId).to.not.equal(firstId);
+    expect(storage.dump()['ably.push.deviceId']).to.equal(secondId);
+  });
+
+  /**
+   * RSH5 — with requestToken pending on a Deferred, activate() and deactivate() are called
+   * back-to-back without awaiting. Per RSH5 the events are handled strictly in call order:
+   * CalledActivate → WaitingForPushDeviceDetails (RSH3a2e), then CalledDeactivate resolves
+   * deactivate() (RSH3b2a) and lands in NotActivated (RSH3b2b). Completing the deferred
+   * token afterwards delivers GotPushDeviceDetails into NotActivated, where RSH3a3a consumes
+   * it — so no registration POST is ever made. (Had the ordering not been respected, the
+   * activation would have proceeded to register, which the zero-requests assertion rules out.)
+   *
+   * The spec defines no resolution for the in-flight activate() in this scenario (RSH3b2
+   * resolves only deactivate), so the test does not await it.
+   */
+  // UTS: rest/unit/RSH5/back-to-back-activate-deactivate-ordered-0
+  it('RSH5 - back-to-back activate then deactivate are handled strictly in order', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new MockPushStorage();
+
+    const tokenDeferred = deferred<ReactNativePushToken>();
+    const client = pushClient(storage, { requestToken: () => tokenDeferred.future });
+
+    const activation = client.push.activate(); // RSH3a2e — handled first
+    const deactivation = client.push.deactivate(undefined as any); // RSH5 — handled only after CalledActivate has transitioned
+    // the spec defines no resolution for `activation` here; guard against a spec-violating
+    // rejection crashing the process (the assertions below would still catch it)
+    activation.catch(() => {});
+
+    await deactivation; // RSH3b2a — resolves with no error
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'NotActivated',
+      'activation state to persist as NotActivated',
+    );
+
+    // The token arrives late: RSH3a3a — consumed in NotActivated, no registration
+    tokenDeferred.complete({ transportType: 'fcm', token: 'fcm-token-1' });
+
+    await flush();
+    expect(captured).to.have.length(0);
+    expect(storage.dump()['ably.push.activationState']).to.equal('NotActivated');
+  });
+
+  /**
+   * RSH3e1, RSH4 — with the RSH3a2a3 validation PATCH held open (machine in
+   * WaitingForRegistrationSync entered via CalledActivate, RSH3a2a4), a second activate()
+   * hits the RSH3e1 carve-out: no transition is defined, so the event queues (RSH4).
+   * Releasing the PATCH resolves the first activate (RSH3e2b), transitions to
+   * WaitingForNewPushDeviceDetails (RSH3e2a), and the dequeued CalledActivate resolves the
+   * second activate from there (RSH3d1a) — with exactly one sync PATCH ever issued.
+   */
+  // UTS: rest/unit/RSH4/second-activate-queued-during-activate-sync-1
+  it('RSH3e1 - a second activate during an activate-triggered sync queues until the sync settles', async function () {
+    // DEVIATION(ably-js): ably-js does not implement the RSH3a2a3 re-activation sync — a
+    // CalledActivate on a device that already has a deviceIdentityToken resolves activate()
+    // immediately from the hydrated WaitingForNewPushDeviceDetails state (or re-queues into it
+    // from NotActivated), with no validation PATCH. The WaitingForRegistrationSync-entered-
+    // via-CalledActivate scenario is therefore unreachable as specced: no PATCH is ever
+    // issued, and waiting for the held PATCH times out.
+    if (!process.env.RUN_DEVIATIONS) {
+      this.skip();
+    }
+
+    let heldPatch: any = null;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'patch' && !heldPatch) {
+        heldPatch = req; // hold the validation sync open
+        return true;
+      }
+      return false;
+    });
+    const storage = new MockPushStorage();
+    await activateInto(storage);
+    const deviceId = storage.dump()['ably.push.deviceId'];
+
+    // A fresh client over registered storage: activate syncs the registration via PATCH (RSH3a2a3)
+    const client = pushClient(storage);
+    const first = client.push.activate();
+    await waitFor(() => !!heldPatch, 'the validation sync PATCH (RSH3a2a3)'); // machine in WaitingForRegistrationSync via CalledActivate (RSH3a2a4)
+
+    // RSH3e1 carve-out applies: no transition defined, so the event queues (RSH4)
+    const second = client.push.activate();
+    await flush();
+    expect(captured).to.have.length(2); // seeding POST + held PATCH; no additional request
+
+    heldPatch.respond_with(200, JSON.parse(heldPatch.body));
+
+    await first; // RSH3e2b
+    await second; // RSH3d1a — the dequeued CalledActivate resolves it from WaitingForNewPushDeviceDetails
+
+    // Exactly one sync PATCH: the queued CalledActivate was consumed by RSH3d1a, not by a second validation
+    const patches = captured.filter((req) => req.method === 'patch');
+    expect(patches).to.have.length(1);
+    expect(patches[0].path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'the released sync to settle in WaitingForNewPushDeviceDetails',
+    );
+  });
+});

--- a/test/uts/rest/unit/push/push_activation_persistence.test.ts
+++ b/test/uts/rest/unit/push/push_activation_persistence.test.ts
@@ -1,0 +1,244 @@
+/**
+ * UTS: Push Activation Persistence Tests
+ *
+ * Spec points: RSH3h, RSH3a2c, RSH8a, RSH8a1, RSH8b, RSH8c
+ * Source: uts/rest/unit/push/push_activation_persistence.md
+ *
+ * The persistence seam of push activation: what the SDK loads from storage on a
+ * fresh start (RSH3h, RSH8a, RSH3a2c), recovery from corrupt or partial persisted
+ * state (RSH8a1), behaviour when persistence itself fails (RSH8b), and when the
+ * registration outcome is persisted (RSH8c).
+ *
+ * Black-box: events are produced by driving the public API and by responding to
+ * the mocked HTTP requests; state is observed through behaviour and, after
+ * operations settle, through the persisted ably.push.* keys.
+ */
+
+import { expect } from 'chai';
+import { restoreAll } from '../../../helpers';
+import {
+  MockPushStorage,
+  mockRegistrationServer,
+  pushClient,
+  waitFor,
+  rejectionOf,
+  installReactNativeFake,
+  restoreReactNativeFake,
+} from './push_helpers';
+
+describe('uts/rest/unit/push/push_activation_persistence', function () {
+  before(function () {
+    installReactNativeFake();
+  });
+
+  after(function () {
+    restoreReactNativeFake();
+  });
+
+  afterEach(function () {
+    restoreAll();
+  });
+
+  // UTS: rest/unit/RSH8a1/corrupt-device-state-discarded-0
+  it('RSH8a1 - corrupt persisted device state discards all persisted state', async function () {
+    // DEVIATION(RSH8a1-discard): ably-js does not discard persisted state when the
+    // id/deviceSecret pair is incomplete — loadPersistedAsync() loads the seeded id with
+    // an undefined deviceSecret and the stale identity token, so the machine treats the
+    // device as already registered and activate() resolves with no token request and no
+    // HTTP request at all (no fresh POST registration, no discarding of the seeded id).
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    let tokenRequests = 0;
+    const capturedRequests = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    storage.seed({
+      'ably.push.deviceId': 'seeded-device-1',
+      // deviceSecret missing — the id/secret pair is incomplete, so the device load must fail
+      'ably.push.deviceIdentityToken': '"stale-token"',
+      'ably.push.activationState': 'WaitingForNewPushDeviceDetails',
+    });
+    const client = pushClient(storage, {
+      requestToken: async () => {
+        tokenRequests += 1;
+        return { transportType: 'fcm', token: 'fcm-token-1' };
+      },
+    });
+
+    await client.push.activate();
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+
+    // Full first-time registration — not the registration sync the stale state would imply
+    expect(tokenRequests).to.equal(1);
+    expect(capturedRequests.length).to.equal(1);
+    const request = capturedRequests[0];
+    expect(request.method).to.equal('post');
+    expect(request.path).to.equal('/push/deviceRegistrations');
+
+    // RSH8a1 (1) — the seeded device identity was discarded; a fresh id was generated
+    const body = JSON.parse(request.body);
+    expect(body.id).to.not.equal('seeded-device-1');
+
+    // The stale identity token was discarded and replaced by the registration result
+    const persisted = storage.dump();
+    expect(persisted['ably.push.deviceId']).to.not.equal('seeded-device-1');
+    expect(JSON.parse(persisted['ably.push.deviceIdentityToken'])).to.equal('ident-token-1');
+  });
+
+  // UTS: rest/unit/RSH8a1/corrupt-machine-state-recovers-1
+  it('RSH8a1 - corrupt persisted machine state recovers without crashing', async function () {
+    // DEVIATION(RSH8a1-corrupt-machine-state): ably-js rehydration does
+    // `new ActivationStates[persistedName](null)` (ensureInitialized(), pushactivation.ts),
+    // so an unrecognised state name makes activate() reject with a TypeError rather than
+    // falling back to NotActivated per RSH3h. Note also that even the spec's fallback path
+    // would deviate: ably-js performs no re-activation sync at all — activate() over a
+    // registered device resolves with no PATCH (the RSH3a2a validation sync asserted below
+    // does not exist in ably-js).
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const capturedRequests = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    storage.seed({
+      'ably.push.deviceId': 'seeded-device-1',
+      'ably.push.deviceSecret': 'seeded-secret',
+      'ably.push.deviceIdentityToken': '"seeded-ident-token"',
+      'ably.push.pushRecipient': '{"transportType":"fcm","registrationToken":"seeded-token-1"}',
+      'ably.push.activationState': 'BogusStateName',
+    });
+    const client = pushClient(storage);
+
+    // Must not crash: the machine falls back to NotActivated (RSH3h), where the
+    // registered device (it has a deviceIdentityToken) is validated per RSH3a2a
+    await client.push.activate();
+
+    expect(capturedRequests.length).to.equal(1);
+    const request = capturedRequests[0];
+    expect(request.method).to.equal('patch');
+    expect(request.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent('seeded-device-1'));
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+  });
+
+  // UTS: rest/unit/RSH3a2c/existing-push-details-skip-token-request-0
+  it('RSH3a2c - persisted push details skip the platform token request', async function () {
+    let tokenRequests = 0;
+    const capturedRequests = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    storage.seed({
+      'ably.push.deviceId': 'seeded-device-1',
+      'ably.push.deviceSecret': 'seeded-secret',
+      // no deviceIdentityToken — the device is not yet registered
+      'ably.push.pushRecipient': '{"transportType":"fcm","registrationToken":"persisted-token-1"}',
+      'ably.push.activationState': 'NotActivated',
+    });
+    const client = pushClient(storage, {
+      requestToken: async () => {
+        tokenRequests += 1;
+        return { transportType: 'fcm', token: 'unexpected-token' };
+      },
+    });
+
+    await client.push.activate();
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+
+    // RSH3a2c — the platform was not consulted
+    expect(tokenRequests).to.equal(0);
+
+    expect(capturedRequests.length).to.equal(1);
+    const request = capturedRequests[0];
+    expect(request.method).to.equal('post');
+    expect(request.path).to.equal('/push/deviceRegistrations');
+
+    const body = JSON.parse(request.body);
+    // RSH3a2b — id and deviceSecret already exist, so they are not regenerated
+    expect(body.id).to.equal('seeded-device-1');
+    // RSH8a — the recipient came from persisted state
+    expect(body.push.recipient).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'persisted-token-1',
+    });
+  });
+
+  // UTS: rest/unit/RSH8b/persist-failure-fails-activate-then-recovers-0
+  it('RSH8b - a persistence failure fails activate; activation recovers once it clears', async function () {
+    const capturedRequests = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    storage.failWrites = true;
+    const client = pushClient(storage);
+
+    // The generated identifiers cannot be persisted: activation fails, no HTTP request
+    const err = await rejectionOf(client.push.activate());
+    expect(err).to.exist;
+    expect(capturedRequests.length).to.equal(0);
+
+    // Once storage works again, the SAME client can activate: the failed device
+    // load must not be cached
+    storage.failWrites = false;
+    await client.push.activate();
+
+    expect(capturedRequests.length).to.equal(1);
+    expect(capturedRequests[0].method).to.equal('post');
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+  });
+
+  // UTS: rest/unit/RSH8c/identity-token-persisted-only-after-registration-0
+  it('RSH8c - deviceIdentityToken is persisted only after successful registration', async function () {
+    let heldPost: any = null;
+    mockRegistrationServer((req) => {
+      if (req.method === 'post' && req.path === '/push/deviceRegistrations' && heldPost === null) {
+        heldPost = req; // hold the registration open
+        return true;
+      }
+      return false;
+    });
+    const storage = new MockPushStorage();
+    const client = pushClient(storage);
+
+    const activation = client.push.activate();
+    await waitFor(() => heldPost !== null, 'the registration POST');
+
+    // Registration in flight: the identity token must not be persisted yet
+    expect(storage.dump()).to.not.have.property('ably.push.deviceIdentityToken');
+
+    heldPost.respond_with(201, { ...JSON.parse(heldPost.body), deviceIdentityToken: { token: 'ident-token-1' } });
+    await activation;
+
+    // After activate resolves and the fire-and-forget writes settle
+    await waitFor(
+      () => storage.dump()['ably.push.deviceIdentityToken'] != null,
+      'the deviceIdentityToken to be persisted',
+    );
+    expect(JSON.parse(storage.dump()['ably.push.deviceIdentityToken'])).to.equal('ident-token-1');
+  });
+
+  // UTS: rest/unit/RSH3h/no-persisted-state-starts-not-activated-0
+  it('RSH3h - with no persisted state the machine starts in NotActivated', async function () {
+    const capturedRequests = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    const client = pushClient(storage);
+
+    // NotActivated is the initial state: deactivate resolves immediately (RSH3a1d)
+    await client.push.deactivate(undefined as any);
+    expect(capturedRequests.length).to.equal(0);
+
+    // and activate runs the full first-time registration flow from NotActivated
+    await client.push.activate();
+    expect(capturedRequests.length).to.equal(1);
+    expect(capturedRequests[0].method).to.equal('post');
+    expect(capturedRequests[0].path).to.equal('/push/deviceRegistrations');
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+  });
+});

--- a/test/uts/rest/unit/push/push_activation_state_machine.test.ts
+++ b/test/uts/rest/unit/push/push_activation_state_machine.test.ts
@@ -1,0 +1,715 @@
+/**
+ * Push Activation State Machine tests
+ *
+ * Spec points: RSH2a, RSH2b, RSH3a1c, RSH3a1d, RSH3a2a, RSH3a2a1, RSH3a2a2, RSH3a2a3, RSH3a2a4,
+ * RSH3a2b, RSH3a2c, RSH3a2d, RSH3a2e, RSH3a3a, RSH3b1a, RSH3b2a, RSH3b2b, RSH3b3a, RSH3b3b,
+ * RSH3b3c, RSH3b3d, RSH3b4a, RSH3b4b, RSH3c1a, RSH3c2a, RSH3c2b, RSH3c2c, RSH3c3a, RSH3c3b,
+ * RSH3d1a, RSH3d1b, RSH3d2a, RSH3d2b, RSH3d2c, RSH3d2c1, RSH3d2d, RSH3e1a, RSH3e1b, RSH3e2a,
+ * RSH3e2b, RSH3e3b, RSH3e3c, RSH3f1a, RSH3f2a, RSH3g1a, RSH3g2a, RSH3g2b, RSH3g2c, RSH3g3a,
+ * RSH3g3b, RSH6a, RSH8h
+ *
+ * Source: uts/rest/unit/push/push_activation_state_machine.md
+ *
+ * Black-box tests of the activation state machine, driven through push.activate()/deactivate()
+ * with mocked HTTP (mockRegistrationServer) and a mocked push platform (MockPushStorage +
+ * requestToken via the ReactNativePush plugin).
+ *
+ * UTS harness adaptations (not deviations):
+ * - registerCallback/deregisterCallback use ably-js's CPS signature (device, callback) rather
+ *   than the UTS return-value form; deregisterCallback receives the whole device, so the
+ *   "deviceId passed to the callback" is read as device.id.
+ * - Device auth (RSH6a): ably-js authenticates device requests with an
+ *   `authorization: Bearer base64(deviceIdentityToken)` header rather than X-Ably-DeviceToken;
+ *   per the spec file's Notes this is an adapt-with-deviation — the adapted check asserts the
+ *   authorization header, and the literal X-Ably-DeviceToken assertion runs under RUN_DEVIATIONS.
+ */
+
+import { expect } from 'chai';
+import { restoreAll } from '../../../helpers';
+import {
+  MockPushStorage,
+  deferred,
+  mockRegistrationServer,
+  pushClient,
+  activateInto,
+  waitFor,
+  flush,
+  rejectionOf,
+  installReactNativeFake,
+  restoreReactNativeFake,
+} from './push_helpers';
+
+/** Settle an operation's outcome without risking an unhandled rejection while other awaits run. */
+function outcomeOf(promise: Promise<unknown>): Promise<{ resolved: boolean; err?: any }> {
+  return promise.then(
+    () => ({ resolved: true }),
+    (err) => ({ resolved: false, err }),
+  );
+}
+
+describe('uts/rest/unit/push/push_activation_state_machine', function () {
+  this.timeout(10000);
+
+  before(installReactNativeFake);
+  after(restoreReactNativeFake);
+  afterEach(restoreAll);
+
+  // UTS: rest/unit/RSH2a/activate-full-flow-0
+  it('RSH2a - activate performs the full registration flow', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = pushClient(mockStorage);
+
+    await client.push.activate();
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state WaitingForNewPushDeviceDetails',
+    );
+
+    expect(captured.length).to.equal(1);
+
+    const request = captured[0];
+    expect(request.method).to.equal('post');
+    expect(request.path).to.equal('/push/deviceRegistrations');
+
+    const body = JSON.parse(request.body);
+    // RSH3b3b — the LocalDevice with push details and deviceSecret
+    expect(body.id).to.not.be.oneOf([null, undefined]);
+    expect(body.deviceSecret).to.not.be.oneOf([null, undefined]);
+    expect(body.platform).to.equal('android');
+    expect(body.formFactor).to.equal('phone');
+    expect(body.push.recipient).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-1',
+    });
+
+    // RSH3c2a + RSH8c — the registration response was applied and persisted
+    const persisted = mockStorage.dump();
+    expect(persisted['ably.push.deviceId']).to.equal(body.id);
+    expect(persisted['ably.push.deviceSecret']).to.not.be.oneOf([null, undefined]);
+    expect(JSON.parse(persisted['ably.push.deviceIdentityToken'])).to.equal('ident-token-1');
+    expect(JSON.parse(persisted['ably.push.pushRecipient'])).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-1',
+    });
+  });
+
+  // UTS: rest/unit/RSH3a2b/device-id-secret-generation-0
+  it('RSH3a2b - generated device identifiers are unique and the secret has sufficient entropy', async function () {
+    mockRegistrationServer();
+    const storageA = new MockPushStorage();
+    const storageB = new MockPushStorage();
+
+    await pushClient(storageA).push.activate();
+    await pushClient(storageB).push.activate();
+    await waitFor(() => storageA.dump()['ably.push.deviceId'] != null, 'storage A deviceId');
+    await waitFor(() => storageB.dump()['ably.push.deviceId'] != null, 'storage B deviceId');
+
+    const a = storageA.dump();
+    const b = storageB.dump();
+
+    // Unique per device
+    expect(a['ably.push.deviceId']).to.not.equal(b['ably.push.deviceId']);
+    expect(a['ably.push.deviceSecret']).to.not.equal(b['ably.push.deviceSecret']);
+
+    expect(a['ably.push.deviceSecret']).to.be.a('string').and.to.not.be.empty;
+    if (process.env.RUN_DEVIATIONS) {
+      // DEVIATION(device-secret-entropy): ably-js generates deviceSecret as a ulid (26-char
+      // Crockford base32, ~16 bytes of entropy), not a base64-encoded digest of >= 32 bytes
+      const decoded = Buffer.from(a['ably.push.deviceSecret'], 'base64');
+      expect(decoded.length).to.be.at.least(32);
+    }
+  });
+
+  // UTS: rest/unit/RSH3b3a/activate-register-callback-0
+  it('RSH3b3a - activate with a custom registerCallback routes registration through the callback', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = pushClient(mockStorage);
+
+    const registeredDevices: any[] = [];
+    const registerCallback = (device: any, callback: any) => {
+      registeredDevices.push(device);
+      callback(null, { deviceIdentityToken: { token: 'custom-ident-1' } });
+    };
+
+    await client.push.activate(registerCallback);
+    await waitFor(() => mockStorage.dump()['ably.push.deviceIdentityToken'] != null, 'deviceIdentityToken persisted');
+
+    // Registration went through the callback, not HTTP
+    expect(captured.length).to.equal(0);
+    expect(registeredDevices.length).to.equal(1);
+    expect(registeredDevices[0].push.recipient).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-1',
+    });
+
+    // RSH8c — the callback's identity token was persisted
+    expect(JSON.parse(mockStorage.dump()['ably.push.deviceIdentityToken'])).to.equal('custom-ident-1');
+  });
+
+  // UTS: rest/unit/RSH3c3a/registration-failure-0
+  it('RSH3c3a - failed registration fails activate and returns to NotActivated', async function () {
+    let failRegistration = true;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'post' && req.path === '/push/deviceRegistrations' && failRegistration) {
+        req.respond_with(400, { error: { message: 'registration rejected', code: 40198, statusCode: 400 } });
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    const client = pushClient(mockStorage);
+
+    const error = await rejectionOf(client.push.activate());
+    expect(error.code).to.equal(40198);
+    expect(captured.length).to.equal(1);
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+
+    // RSH3c3b — from NotActivated, activation can be retried successfully
+    failRegistration = false;
+    await client.push.activate();
+    expect(captured.length).to.equal(2);
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'WaitingForNewPushDeviceDetails persisted',
+    );
+  });
+
+  // UTS: rest/unit/RSH3b4a/token-failure-0
+  it('RSH3b4a - failed token acquisition fails activate and returns to NotActivated', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = pushClient(mockStorage, {
+      requestToken: async () => {
+        throw new Error('permission denied');
+      },
+    });
+
+    const error = await rejectionOf(client.push.activate());
+    expect(error.message).to.contain('permission denied');
+
+    // No registration was attempted
+    expect(captured.length).to.equal(0);
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3a2a3/activate-existing-registration-sync-0
+  it('RSH3a2a3 - activate on an already-registered device syncs the registration via PATCH', async function () {
+    // DEVIATION(no-reactivation-sync): ably-js performs no RSH3a2a validation — a fresh client
+    // over registered storage resolves activate() immediately with no PATCH/PUT request
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    // A fresh client over the same storage simulates an app restart
+    const client = pushClient(mockStorage);
+    await client.push.activate();
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'WaitingForNewPushDeviceDetails persisted',
+    );
+
+    // One POST from the seeding activation, then exactly one sync PATCH — no second POST
+    expect(captured.length).to.equal(2);
+    const request = captured[1];
+    expect(request.method).to.equal('patch');
+    expect(request.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+
+    // RSH3d3b — changed fields only, with the complete recipient
+    const body = JSON.parse(request.body);
+    expect(body.push.recipient).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-1',
+    });
+  });
+
+  // UTS: rest/unit/RSH3a2a2/activate-existing-registration-register-callback-0
+  it('RSH3a2a2 - activate on an already-registered device with a custom registerCallback', async function () {
+    // DEVIATION(no-reactivation-sync): ably-js performs no RSH3a2a validation on a fresh client
+    // over registered storage — activate() resolves immediately without calling registerCallback
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    const registeredDevices: any[] = [];
+    const registerCallback = (device: any, callback: any) => {
+      registeredDevices.push(device);
+      callback(null, { deviceIdentityToken: { token: 'ident-token-1' } });
+    };
+
+    const client = pushClient(mockStorage);
+    await client.push.activate(registerCallback);
+
+    // The validation went through the callback: no requests beyond the seeding POST
+    expect(captured.length).to.equal(1);
+    expect(registeredDevices.length).to.equal(1);
+    expect(registeredDevices[0].id).to.equal(deviceId);
+  });
+
+  // UTS: rest/unit/RSH3a2a1/activate-clientid-mismatch-0
+  it('RSH3a2a1 - activate fails with 61002 when the client identity conflicts with the registered device', async function () {
+    // DEVIATION(no-reactivation-sync): ably-js does not persist the registered device's clientId
+    // (LocalDevice.clientId is always overwritten with the current client's auth.clientId on
+    // load), so the RSH3a2a1 61002 check never fires — activate() resolves immediately
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    await activateInto(mockStorage, { clientId: 'alice' });
+
+    const client = pushClient(mockStorage, { clientId: 'bob' });
+    const error = await rejectionOf(client.push.activate());
+    expect(error.code).to.equal(61002);
+
+    // No validation request was made — only the seeding POST
+    expect(captured.length).to.equal(1);
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'AfterRegistrationSyncFailed',
+      'AfterRegistrationSyncFailed persisted',
+    );
+  });
+
+  // UTS: rest/unit/RSH3d1a/activate-when-registered-resolves-0
+  it('RSH3d1a - activate when already registered in the same session resolves without any request', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+
+    await client.push.activate();
+
+    // No additional request beyond the original registration POST
+    expect(captured.length).to.equal(1);
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'WaitingForNewPushDeviceDetails persisted',
+    );
+  });
+
+  // UTS: rest/unit/RSH3b1a/activate-while-waiting-push-details-0
+  it('RSH3b1a - repeated activate while waiting for push device details is idempotent', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+
+    const tokenDeferred = deferred<any>();
+    let tokenRequests = 0;
+    const client = pushClient(mockStorage, {
+      requestToken: () => {
+        tokenRequests += 1;
+        return tokenDeferred.future;
+      },
+    });
+
+    const first = client.push.activate(); // pends on requestToken
+    const second = outcomeOf(client.push.activate()); // RSH3b1a — self-transition
+
+    tokenDeferred.complete({ transportType: 'fcm', token: 'fcm-token-1' });
+
+    await first;
+    const secondOutcome = await second;
+    if (process.env.RUN_DEVIATIONS) {
+      // DEVIATION(concurrent-activate-rejected): ably-js rejects a second activate() while one is
+      // in flight (40000 'Activation already in progress') instead of resolving both per RSH3b1a
+      expect(secondOutcome.resolved).to.equal(true);
+    } else {
+      expect(secondOutcome.resolved).to.equal(false);
+      expect(secondOutcome.err.code).to.equal(40000);
+      expect(secondOutcome.err.message).to.match(/already in progress/);
+    }
+
+    expect(tokenRequests).to.equal(1);
+    expect(captured.length).to.equal(1);
+    expect(captured[0].method).to.equal('post');
+  });
+
+  // UTS: rest/unit/RSH3b2a/deactivate-while-waiting-push-details-0
+  it('RSH3b2a - deactivate while waiting for push device details returns to NotActivated', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+
+    const tokenDeferred = deferred<any>();
+    const client = pushClient(mockStorage, { requestToken: () => tokenDeferred.future });
+
+    const activation = client.push.activate(); // pends on requestToken
+    void activation.catch(() => {}); // never settles in ably-js; guard against a surprise rejection
+
+    await client.push.deactivate(); // RSH3b2a — resolves with no error
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+
+    // The token arrives late: RSH3a3a — consumed in NotActivated, no registration
+    tokenDeferred.complete({ transportType: 'fcm', token: 'fcm-token-1' });
+
+    // allow any erroneous request to surface (UTS poll_until(() => false, ...))
+    for (let i = 0; i < 5; i++) {
+      await flush();
+    }
+    expect(captured.length).to.equal(0);
+    expect(mockStorage.dump()['ably.push.activationState']).to.equal('NotActivated');
+  });
+
+  // UTS: rest/unit/RSH3c1a/activate-while-registering-0
+  it('RSH3c1a - repeated activate while device registration is in flight is idempotent', async function () {
+    let heldPost: any = null;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'post' && req.path === '/push/deviceRegistrations' && heldPost == null) {
+        heldPost = req; // hold the registration open
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    const client = pushClient(mockStorage);
+
+    const first = client.push.activate();
+    await waitFor(() => heldPost != null, 'the held registration POST');
+
+    const second = outcomeOf(client.push.activate()); // RSH3c1a — self-transition, no second POST
+
+    heldPost.respond_with(201, { ...JSON.parse(heldPost.body), deviceIdentityToken: { token: 'ident-token-1' } });
+
+    await first;
+    const secondOutcome = await second;
+    if (process.env.RUN_DEVIATIONS) {
+      // DEVIATION(concurrent-activate-rejected): ably-js rejects a second activate() while one is
+      // in flight (40000 'Activation already in progress') instead of resolving both per RSH3c1a
+      expect(secondOutcome.resolved).to.equal(true);
+    } else {
+      expect(secondOutcome.resolved).to.equal(false);
+      expect(secondOutcome.err.code).to.equal(40000);
+      expect(secondOutcome.err.message).to.match(/already in progress/);
+    }
+
+    expect(captured.length).to.equal(1);
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'WaitingForNewPushDeviceDetails persisted',
+    );
+  });
+
+  // UTS: rest/unit/RSH2b/deactivate-full-flow-0
+  it('RSH2b - deactivate deregisters the device and clears local state', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    await client.push.deactivate();
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+
+    expect(captured.length).to.equal(2);
+    const request = captured[1];
+    expect(request.method).to.equal('delete');
+    expect(request.path).to.equal('/push/deviceRegistrations');
+    expect(request.url.searchParams.get('deviceId')).to.equal(deviceId);
+    expect(request.params.deviceId).to.equal(deviceId);
+
+    // RSH3d2b + RSH6a — push device authentication. Adapted check: ably-js authenticates the
+    // device with an authorization Bearer header carrying base64(deviceIdentityToken).
+    expect(request.headers.authorization).to.equal('Bearer ' + Buffer.from('ident-token-1').toString('base64'));
+    if (process.env.RUN_DEVIATIONS) {
+      // DEVIATION(device-auth-header): ably-js sends no X-Ably-DeviceToken header (RSH6a)
+      expect(request.headers['X-Ably-DeviceToken'] ?? request.headers['x-ably-devicetoken']).to.equal('ident-token-1');
+    }
+
+    // RSH3g2a — the registered identity is cleared from storage, not just memory
+    const persisted = mockStorage.dump();
+    expect(persisted).to.not.have.property('ably.push.deviceIdentityToken');
+    expect(persisted).to.not.have.property('ably.push.pushRecipient');
+  });
+
+  // UTS: rest/unit/RSH3d2a/deactivate-deregister-callback-0
+  it('RSH3d2a - deactivate with a custom deregisterCallback routes deregistration through the callback', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    const deregisteredIds: string[] = [];
+    const deregisterCallback = (device: any, callback: any) => {
+      deregisteredIds.push(device.id);
+      callback(null);
+    };
+
+    await client.push.deactivate(deregisterCallback);
+
+    // Deregistration went through the callback: no DELETE
+    expect(captured.length).to.equal(1); // just the seeding POST
+    expect(deregisteredIds).to.deep.equal([deviceId]);
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3a1c/deactivate-not-activated-with-token-0
+  it('RSH3a1c - deactivate from NotActivated with a registered device still deregisters', async function () {
+    // DEVIATION(no-deregister-from-notactivated): ably-js's NotActivated state resolves
+    // CalledDeactivate immediately without checking deviceIdentityToken — no DELETE is issued
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    mockStorage.seed({
+      'ably.push.deviceId': 'seeded-device-1',
+      'ably.push.deviceSecret': 'seeded-secret',
+      'ably.push.deviceIdentityToken': '"seeded-ident-token"',
+      'ably.push.activationState': 'NotActivated',
+    });
+    const client = pushClient(mockStorage);
+
+    await client.push.deactivate();
+
+    expect(captured.length).to.equal(1);
+    const request = captured[0];
+    expect(request.method).to.equal('delete');
+    expect(request.url.searchParams.get('deviceId')).to.equal('seeded-device-1');
+    expect(request.headers['X-Ably-DeviceToken'] ?? request.headers['x-ably-devicetoken']).to.equal(
+      'seeded-ident-token',
+    );
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3a1d/deactivate-not-activated-0
+  it('RSH3a1d - deactivate from NotActivated with no registration resolves without any request', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = pushClient(mockStorage);
+
+    await client.push.deactivate();
+
+    expect(captured.length).to.equal(0);
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3d2c1/deregister-401-succeeds-0
+  it('RSH3d2c1 - deregistration treats 401 as success', async function () {
+    // DEVIATION(deregister-status-classification): ably-js does not implement RSH3d2c1 — any
+    // non-2xx DELETE response (including 401) fires DeregistrationFailed, so deactivate() rejects
+    // and the registration is not cleared
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    mockRegistrationServer((req) => {
+      if (req.method === 'delete') {
+        req.respond_with(401, { error: { message: 'unauthorized', code: 40100, statusCode: 401 } });
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+
+    await client.push.deactivate(); // resolves despite the 401
+
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+    const persisted = mockStorage.dump();
+    expect(persisted).to.not.have.property('ably.push.deviceIdentityToken');
+  });
+
+  // UTS: rest/unit/RSH3d2c1/deregister-40005-succeeds-1
+  it('RSH3d2c1 - deregistration treats error code 40005 as success', async function () {
+    // DEVIATION(deregister-status-classification): ably-js does not implement RSH3d2c1 — a DELETE
+    // failing with error code 40005 fires DeregistrationFailed, so deactivate() rejects
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    mockRegistrationServer((req) => {
+      if (req.method === 'delete') {
+        req.respond_with(400, { error: { message: 'invalid credentials', code: 40005, statusCode: 400 } });
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+
+    await client.push.deactivate(); // resolves despite the 40005
+
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3g3b/deregister-failure-rollback-0
+  it('RSH3g3b - deregistration failure fails deactivate and rolls back to the previous state', async function () {
+    let failDelete = true;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'delete' && failDelete) {
+        // a non-retriable 4xx: a 5xx would additionally exercise RSC15 fallback-host retries
+        req.respond_with(400, { error: { message: 'deregistration rejected', code: 40198, statusCode: 400 } });
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+
+    const error = await rejectionOf(client.push.deactivate());
+    expect(error.code).to.equal(40198);
+
+    // RSH3g3b — still registered: the identity token survives the failed deregistration
+    expect(mockStorage.dump()['ably.push.deviceIdentityToken']).to.not.be.oneOf([null, undefined]);
+
+    // Retry succeeds from the rolled-back state
+    failDelete = false;
+    await client.push.deactivate();
+    expect(captured.length).to.equal(3); // POST + failed DELETE + successful DELETE
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3g1a/deactivate-while-deregistering-0
+  it('RSH3g1a - repeated deactivate while deregistration is in flight is idempotent', async function () {
+    let heldDelete: any = null;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'delete' && heldDelete == null) {
+        heldDelete = req; // hold the deregistration open
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+
+    const first = client.push.deactivate();
+    await waitFor(() => heldDelete != null, 'the held deregistration DELETE');
+
+    const second = outcomeOf(client.push.deactivate()); // RSH3g1a — self-transition, no second DELETE
+
+    heldDelete.respond_with(204, '');
+
+    await first;
+    const secondOutcome = await second;
+    if (process.env.RUN_DEVIATIONS) {
+      // DEVIATION(concurrent-deactivate-rejected): ably-js rejects a second deactivate() while one
+      // is in flight (40000 'Deactivation already in progress') instead of resolving both per RSH3g1a
+      expect(secondOutcome.resolved).to.equal(true);
+    } else {
+      expect(secondOutcome.resolved).to.equal(false);
+      expect(secondOutcome.err.code).to.equal(40000);
+      expect(secondOutcome.err.message).to.match(/already in progress/);
+    }
+
+    // Exactly one DELETE was issued
+    const deleteRequests = captured.filter((req: any) => req.method === 'delete');
+    expect(deleteRequests.length).to.equal(1);
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3e3c/sync-failure-then-reactivate-0
+  it('RSH3e3c - a failed registration sync fails activate; re-activating retries the sync', async function () {
+    // DEVIATION(no-reactivation-sync): ably-js performs no RSH3a2a PATCH sync on a fresh client
+    // over registered storage — activate() resolves immediately, so the failing-sync setup this
+    // test depends on is unreachable via activate()
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    let failPatch = true;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'patch' && failPatch) {
+        req.respond_with(400, { error: { message: 'sync rejected', code: 40199, statusCode: 400 } });
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    // Fresh client over registered storage: activate syncs via PATCH, which fails
+    const client = pushClient(mockStorage);
+    const error = await rejectionOf(client.push.activate());
+    expect(error.code).to.equal(40199);
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'AfterRegistrationSyncFailed',
+      'AfterRegistrationSyncFailed persisted',
+    );
+
+    // RSH3f1a — activate again; the machine re-runs the RSH3a2a validation
+    failPatch = false;
+    await client.push.activate();
+
+    const patchRequests = captured.filter((req: any) => req.method === 'patch');
+    expect(patchRequests.length).to.equal(2);
+    expect(patchRequests[1].path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'WaitingForNewPushDeviceDetails persisted',
+    );
+  });
+
+  // UTS: rest/unit/RSH3f2a/deactivate-after-sync-failure-0
+  it('RSH3f2a - deactivate from AfterRegistrationSyncFailed deregisters normally', async function () {
+    // DEVIATION(no-reactivation-sync): the setup drives AfterRegistrationSyncFailed via a failing
+    // PATCH issued by activate() on a fresh client, but ably-js issues no such PATCH — activate()
+    // resolves immediately, making the written setup unreachable
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'patch') {
+        req.respond_with(400, { error: { message: 'sync rejected', code: 40199, statusCode: 400 } });
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    const client = pushClient(mockStorage);
+    await rejectionOf(client.push.activate()); // drive into AfterRegistrationSyncFailed
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'AfterRegistrationSyncFailed',
+      'AfterRegistrationSyncFailed persisted',
+    );
+
+    await client.push.deactivate();
+
+    const deleteRequests = captured.filter((req: any) => req.method === 'delete');
+    expect(deleteRequests.length).to.equal(1);
+    expect(deleteRequests[0].url.searchParams.get('deviceId')).to.equal(deviceId);
+    await waitFor(() => mockStorage.dump()['ably.push.activationState'] === 'NotActivated', 'NotActivated persisted');
+  });
+
+  // UTS: rest/unit/RSH3g3b/deregister-failure-rollback-after-sync-failed-1
+  it('RSH3g3b - deregistration failure from AfterRegistrationSyncFailed rolls back to AfterRegistrationSyncFailed', async function () {
+    // DEVIATION(no-reactivation-sync): the setup drives AfterRegistrationSyncFailed via a failing
+    // PATCH issued by activate() on a fresh client, but ably-js issues no such PATCH — activate()
+    // resolves immediately, making the written setup unreachable
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    let failPatch = true;
+    let failDelete = true;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'patch' && failPatch) {
+        req.respond_with(400, { error: { message: 'sync rejected', code: 40199, statusCode: 400 } });
+        return true;
+      }
+      if (req.method === 'delete' && failDelete) {
+        // a non-retriable 4xx: a 5xx would additionally exercise RSC15 fallback-host retries
+        req.respond_with(400, { error: { message: 'deregistration rejected', code: 40198, statusCode: 400 } });
+        return true;
+      }
+      return false;
+    });
+    const mockStorage = new MockPushStorage();
+    await activateInto(mockStorage);
+
+    const client = pushClient(mockStorage);
+    await rejectionOf(client.push.activate()); // -> AfterRegistrationSyncFailed
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'AfterRegistrationSyncFailed',
+      'AfterRegistrationSyncFailed persisted',
+    );
+
+    const error = await rejectionOf(client.push.deactivate());
+    expect(error.code).to.equal(40198);
+
+    // Back in AfterRegistrationSyncFailed: activate re-syncs via PATCH (RSH3f1a)
+    failPatch = false;
+    await client.push.activate();
+    const patchRequests = captured.filter((req: any) => req.method === 'patch');
+    expect(patchRequests.length).to.equal(2);
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'WaitingForNewPushDeviceDetails persisted',
+    );
+  });
+});

--- a/test/uts/rest/unit/push/push_device_auth.test.ts
+++ b/test/uts/rest/unit/push/push_device_auth.test.ts
@@ -1,0 +1,274 @@
+/**
+ * UTS: Push Device Authentication Tests
+ *
+ * Spec points: RSH6, RSH6a, RSH6b, RSH1b3, RSH1b5, RSH1c3, RSH1c4, RSH3d2b
+ * Source: uts/rest/unit/push/push_device_auth.md
+ *
+ * Push device authentication (RSH6): how an activated (or partially activated)
+ * push target device authenticates itself for requests operating on its own
+ * registration, and the admin API clauses (RSH1b3/RSH1b5/RSH1c3/RSH1c4) that
+ * require it when the referenced deviceId is that of the present client.
+ *
+ * DEVIATIONS (per the spec's Notes; see the report accompanying these tests):
+ * - ably-js's common push admin implementation (src/common/lib/client/push.ts)
+ *   does not implement the own-device auth clauses of RSH1b3/RSH1b5/RSH1c3/RSH1c4
+ *   at all — its admin requests never carry device auth. The RSH6a header
+ *   assertions below are guarded behind RUN_DEVIATIONS.
+ * - ably-js does not implement RSH6b (X-Ably-DeviceSecret): its device-auth path
+ *   (LocalDevice.getAuthDetails) throws "Unable to update device registration;
+ *   no deviceIdentityToken" (50000) when there is no deviceIdentityToken, and
+ *   its identity-token auth uses `authorization: Bearer <base64(token)>` rather
+ *   than X-Ably-DeviceToken. The RSH6b test is skipped as a whole-test deviation.
+ */
+
+import { expect } from 'chai';
+import { restoreAll } from '../../../helpers';
+import {
+  MockPushStorage,
+  mockRegistrationServer,
+  pushClient,
+  activateInto,
+  waitFor,
+  installReactNativeFake,
+  restoreReactNativeFake,
+} from './push_helpers';
+
+/** Case-insensitive request header lookup. */
+function headerValue(req: any, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(req.headers ?? {})) {
+    if (key.toLowerCase() === lower) {
+      return value as string;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * mockRegistrationServer() 500s unrouted paths, so tests exercising the admin
+ * channelSubscriptions endpoints route them through this overrides handler.
+ */
+function channelSubscriptionRoutes(req: any): boolean {
+  if (req.method === 'post' && req.path === '/push/channelSubscriptions') {
+    req.respond_with(200, JSON.parse(req.body));
+    return true;
+  }
+  if (req.method === 'delete' && req.path === '/push/channelSubscriptions') {
+    req.respond_with(204, '');
+    return true;
+  }
+  return false;
+}
+
+describe('uts/rest/unit/push/push_device_auth', function () {
+  before(function () {
+    installReactNativeFake();
+  });
+
+  after(function () {
+    restoreReactNativeFake();
+  });
+
+  afterEach(restoreAll);
+
+  /**
+   * RSH6a, RSH1b3 - deviceRegistrations.save for the present activated device
+   * includes device auth: after full activation, an admin save() whose
+   * DeviceDetails.id is the local device's id carries the X-Ably-DeviceToken
+   * header with the registered deviceIdentityToken.
+   */
+  // UTS: rest/unit/RSH6a/admin-device-registrations-save-own-device-0
+  it('RSH6a, RSH1b3 - deviceRegistrations.save for the present activated device includes device auth', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    await client.push.admin.deviceRegistrations.save({
+      id: deviceId,
+      platform: 'android',
+      formFactor: 'phone',
+      push: {
+        recipient: { transportType: 'fcm', registrationToken: 'fcm-token-1' },
+      },
+    });
+
+    // The seeding activation POST, then the admin save PUT
+    expect(captured).to.have.length(2);
+
+    const request = captured[1];
+    expect(request.method).to.equal('put');
+    expect(request.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+
+    // RSH1b3 + RSH6a — the deviceId is that of the present activated client,
+    // so the request must include push device authentication.
+    // DEVIATION(RSH6a, RSH1b3): ably-js's push admin adds no device-auth headers
+    // at all — the PUT carries only normal key/token auth (Authorization: Basic).
+    if (process.env.RUN_DEVIATIONS) {
+      expect(headerValue(request, 'X-Ably-DeviceToken')).to.equal('ident-token-1');
+    }
+  });
+
+  /**
+   * RSH6a, RSH1b3 - deviceRegistrations.save for a different device carries no
+   * device auth: the same activated client saving a DeviceDetails for a
+   * different deviceId sends no device-auth header.
+   */
+  // UTS: rest/unit/RSH6a/admin-save-other-device-no-device-auth-1
+  it('RSH6a, RSH1b3 - deviceRegistrations.save for a different device carries no device auth', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+
+    await client.push.admin.deviceRegistrations.save({
+      id: 'other-device-1',
+      platform: 'ios',
+      formFactor: 'tablet',
+      push: {
+        recipient: { transportType: 'apns', deviceToken: 'apns-token-1' },
+      },
+    });
+
+    expect(captured).to.have.length(2);
+
+    const request = captured[1];
+    expect(request.method).to.equal('put');
+    expect(request.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent('other-device-1'));
+
+    // The deviceId is not that of the present client — no device auth
+    expect(headerValue(request, 'X-Ably-DeviceToken')).to.equal(undefined);
+    expect(headerValue(request, 'X-Ably-DeviceSecret')).to.equal(undefined);
+  });
+
+  /**
+   * RSH6a, RSH1c3, RSH1c4 - channelSubscriptions save/remove for the present
+   * device include device auth: an activated client saving, then removing, a
+   * channel subscription for its own deviceId includes the X-Ably-DeviceToken
+   * header on both requests.
+   */
+  // UTS: rest/unit/RSH6a/admin-channel-subscriptions-save-own-device-2
+  it('RSH6a, RSH1c3, RSH1c4 - channelSubscriptions save/remove for the present device include device auth', async function () {
+    const captured = mockRegistrationServer(channelSubscriptionRoutes);
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    // ably-js has no PushChannelSubscription.forDevice factory (PCS5); per the
+    // spec's Notes the subscription may be constructed by an equivalent means.
+    const subscription = { channel: 'push-test-channel', deviceId };
+
+    await client.push.admin.channelSubscriptions.save(subscription); // RSH1c3
+    await client.push.admin.channelSubscriptions.remove(subscription); // RSH1c4
+
+    // Seeding POST, then the subscription POST, then the subscription DELETE
+    expect(captured).to.have.length(3);
+
+    // RSH1c3 — the save POST includes device auth
+    const saveRequest = captured[1];
+    expect(saveRequest.method).to.equal('post');
+    expect(saveRequest.path).to.equal('/push/channelSubscriptions');
+    const body = JSON.parse(saveRequest.body);
+    expect(body.channel).to.equal('push-test-channel');
+    expect(body.deviceId).to.equal(deviceId);
+
+    // RSH1c4 — the remove DELETE includes device auth
+    const removeRequest = captured[2];
+    expect(removeRequest.method).to.equal('delete');
+    expect(removeRequest.path).to.equal('/push/channelSubscriptions');
+    expect(removeRequest.url.searchParams.get('channel')).to.equal('push-test-channel');
+    expect(removeRequest.url.searchParams.get('deviceId')).to.equal(deviceId);
+
+    // DEVIATION(RSH6a, RSH1c3, RSH1c4): ably-js's push admin adds no device-auth
+    // headers at all — both requests carry only normal key/token auth.
+    if (process.env.RUN_DEVIATIONS) {
+      expect(headerValue(saveRequest, 'X-Ably-DeviceToken')).to.equal('ident-token-1');
+      expect(headerValue(removeRequest, 'X-Ably-DeviceToken')).to.equal('ident-token-1');
+    }
+  });
+
+  /**
+   * RSH6a, RSH1b5 - deviceRegistrations.removeWhere for the present device
+   * includes device auth: an activated client issuing removeWhere(deviceId:
+   * <own id>) includes the X-Ably-DeviceToken header on the DELETE.
+   */
+  // UTS: rest/unit/RSH6a/admin-remove-where-own-device-3
+  it('RSH6a, RSH1b5 - deviceRegistrations.removeWhere for the present device includes device auth', async function () {
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = await activateInto(mockStorage);
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+
+    await client.push.admin.deviceRegistrations.removeWhere({ deviceId });
+
+    expect(captured).to.have.length(2);
+
+    const request = captured[1];
+    expect(request.method).to.equal('delete');
+    expect(request.path).to.equal('/push/deviceRegistrations');
+    expect(request.url.searchParams.get('deviceId')).to.equal(deviceId);
+
+    // RSH1b5 + RSH6a — the deviceId param is that of the present activated client
+    // DEVIATION(RSH6a, RSH1b5): ably-js's push admin adds no device-auth headers
+    // at all — the DELETE carries only normal key/token auth.
+    if (process.env.RUN_DEVIATIONS) {
+      expect(headerValue(request, 'X-Ably-DeviceToken')).to.equal('ident-token-1');
+    }
+  });
+
+  /**
+   * RSH6b, RSH3d2b - a device with a deviceSecret but no deviceIdentityToken
+   * authenticates with X-Ably-DeviceSecret: activation via a custom
+   * registerCallback whose result confers no deviceIdentityToken, then
+   * deactivate() must carry X-Ably-DeviceSecret on the deregistration DELETE.
+   */
+  // UTS: rest/unit/RSH6b/device-secret-auth-before-identity-token-0
+  it('RSH6b, RSH3d2b - a device with a deviceSecret but no deviceIdentityToken authenticates with X-Ably-DeviceSecret', async function () {
+    // DEVIATION(RSH6b, RSH3d2b): ably-js does not implement deviceSecret device
+    // auth. A registerCallback result without a deviceIdentityToken crashes the
+    // activation state machine (TypeError reading `.token` of undefined in
+    // WaitingForDeviceRegistration.processEvent), so activate() never settles;
+    // and the deregistration path (LocalDevice.getAuthDetails) throws
+    // "Unable to update device registration; no deviceIdentityToken" (50000)
+    // instead of falling back to X-Ably-DeviceSecret, so deactivate() never
+    // settles either. Even with an identity token, ably-js's device auth is
+    // `authorization: Bearer <base64(token)>`, not the RSH6a/RSH6b headers.
+    if (!process.env.RUN_DEVIATIONS) this.skip();
+
+    const captured = mockRegistrationServer();
+    const mockStorage = new MockPushStorage();
+    const client = pushClient(mockStorage);
+
+    // Registration succeeds but confers no deviceIdentityToken (ably-js's
+    // RegisterCallback is callback-style).
+    const registerCallback = (_device: any, callback: (err: any, deviceRegistration?: any) => void) => {
+      callback(null, {});
+    };
+
+    await client.push.activate(registerCallback);
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+
+    const deviceId = mockStorage.dump()['ably.push.deviceId'];
+    const deviceSecret = mockStorage.dump()['ably.push.deviceSecret'];
+
+    await client.push.deactivate();
+    await waitFor(
+      () => mockStorage.dump()['ably.push.activationState'] === 'NotActivated',
+      'activation state to persist as NotActivated',
+    );
+
+    // Registration went through the callback, so the only HTTP request is the DELETE
+    expect(captured).to.have.length(1);
+
+    const request = captured[0];
+    expect(request.method).to.equal('delete');
+    expect(request.path).to.equal('/push/deviceRegistrations');
+    expect(request.url.searchParams.get('deviceId')).to.equal(deviceId);
+
+    // RSH6b — deviceSecret auth, since the device has no deviceIdentityToken
+    expect(headerValue(request, 'X-Ably-DeviceSecret')).to.equal(deviceSecret);
+    expect(headerValue(request, 'X-Ably-DeviceToken')).to.equal(undefined);
+  });
+});

--- a/test/uts/rest/unit/push/push_helpers.ts
+++ b/test/uts/rest/unit/push/push_helpers.ts
@@ -1,0 +1,243 @@
+/**
+ * Shared helpers for the UTS push activation test suite.
+ *
+ * Maps the UTS harness constructs (uts/rest/unit/helpers/mock_push_platform.md)
+ * onto ably-js's push seam: `install_push_platform(...)` becomes a per-client
+ * ReactNativePush plugin carrying the mock storage and requestToken;
+ * `MockPushStorage` implements the AsyncStorage-shaped ReactNativePushStorage
+ * with the UTS mock extensions (dump/seed/fail flags/onOperation).
+ *
+ * The ReactNativePush plugin reads require('react-native').Platform.OS inside
+ * create(); react-native is not resolvable in Node, so installReactNativeFake()
+ * intercepts module loading (call in before(), restore in after()).
+ */
+
+import Module from 'module';
+import { MockHttpClient } from '../../../mock_http';
+import { Ably, installMockHttp } from '../../../helpers';
+import ReactNativePush from '../../../../../src/plugins/react-native-push';
+import type { ReactNativePushToken } from '../../../../../src/plugins/react-native-push';
+
+// ---------------------------------------------------------------------------
+// react-native module fake
+
+export const fakeReactNative = { Platform: { OS: 'android' } };
+const originalModuleLoad = (Module as any)._load;
+
+export function installReactNativeFake(): void {
+  (Module as any)._load = function (request: string, ...rest: any[]) {
+    if (request === 'react-native') {
+      return fakeReactNative;
+    }
+    return originalModuleLoad.call(this, request, ...rest);
+  };
+}
+
+export function restoreReactNativeFake(): void {
+  (Module as any)._load = originalModuleLoad;
+  fakeReactNative.Platform.OS = 'android';
+}
+
+// ---------------------------------------------------------------------------
+// MockPushStorage (mock_push_platform.md)
+
+export interface StorageOperation {
+  type: 'getItem' | 'setItem' | 'removeItem';
+  key: string;
+  value?: string;
+}
+
+/**
+ * In-memory PushKeyValueStorage with the UTS mock extensions. The optional
+ * onOperation handler runs synchronously before each operation is applied;
+ * if it throws, the operation rejects and the contents are not modified.
+ */
+export class MockPushStorage {
+  private data = new Map<string, string>();
+  failWrites = false;
+  failReads = false;
+
+  constructor(private onOperation?: (op: StorageOperation) => void) {}
+
+  async getItem(key: string): Promise<string | null> {
+    this.onOperation?.({ type: 'getItem', key });
+    if (this.failReads) {
+      throw new Error('storage unavailable (reads)');
+    }
+    return this.data.has(key) ? this.data.get(key)! : null;
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    this.onOperation?.({ type: 'setItem', key, value });
+    if (this.failWrites) {
+      throw new Error('storage unavailable (writes)');
+    }
+    this.data.set(key, value);
+  }
+
+  async removeItem(key: string): Promise<void> {
+    this.onOperation?.({ type: 'removeItem', key });
+    if (this.failWrites) {
+      throw new Error('storage unavailable (writes)');
+    }
+    this.data.delete(key);
+  }
+
+  /** Test-only synchronous inspection of the current contents. */
+  dump(): Record<string, string> {
+    return Object.fromEntries(this.data);
+  }
+
+  /** Test-only seeding: simulate state persisted by a previous app run. */
+  seed(entries: Record<string, string>): void {
+    for (const [key, value] of Object.entries(entries)) {
+      this.data.set(key, value);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Deferred
+
+export interface Deferred<T> {
+  future: Promise<T>;
+  complete(value: T): void;
+  fail(error: unknown): void;
+}
+
+export function deferred<T>(): Deferred<T> {
+  let complete!: (value: T) => void;
+  let fail!: (error: unknown) => void;
+  const future = new Promise<T>((resolve, reject) => {
+    complete = resolve;
+    fail = reject;
+  });
+  return { future, complete, fail };
+}
+
+// ---------------------------------------------------------------------------
+// mock_registration_server
+
+/**
+ * Installs a MockHttpClient routing the device-registration endpoints, per the
+ * UTS shared setup. `overrides(req)` is consulted first; return true if the
+ * override handled (or held) the request. Returns the captured-requests array.
+ */
+export function mockRegistrationServer(overrides?: (req: any) => boolean): any[] {
+  const captured: any[] = [];
+  const mock = new MockHttpClient({
+    onConnectionAttempt: (conn) => conn.respond_with_success(),
+    onRequest: (req) => {
+      captured.push(req);
+      if (overrides && overrides(req)) {
+        return;
+      }
+      if (req.method === 'post' && req.path === '/push/deviceRegistrations') {
+        req.respond_with(201, { ...JSON.parse(req.body), deviceIdentityToken: { token: 'ident-token-1' } });
+      } else if (req.method === 'put' && req.path.startsWith('/push/deviceRegistrations/')) {
+        req.respond_with(200, JSON.parse(req.body));
+      } else if (req.method === 'patch' && req.path.startsWith('/push/deviceRegistrations/')) {
+        req.respond_with(200, JSON.parse(req.body));
+      } else if (req.method === 'delete' && req.path === '/push/deviceRegistrations') {
+        req.respond_with(204, '');
+      } else {
+        req.respond_with(500, { error: { message: 'unexpected request ' + req.method + ' ' + req.path, code: 50000 } });
+      }
+    },
+  });
+  installMockHttp(mock);
+  return captured;
+}
+
+// ---------------------------------------------------------------------------
+// push_client / activate_into
+
+export interface PushClientOptions {
+  clientId?: string;
+  /** Literal token for requestToken to resolve with (default fcm-token-1). */
+  token?: ReactNativePushToken;
+  /** Full requestToken override; takes precedence over `token`. */
+  requestToken?: () => Promise<ReactNativePushToken>;
+  /** react-native Platform.OS for this client's plugin ('android' | 'ios'). */
+  platform?: string;
+  /** Extra ClientOptions merged in (e.g. authCallback instead of key). */
+  clientOptions?: Record<string, any>;
+}
+
+/**
+ * UTS `push_client(storage, ...)`: installs the push platform (as a per-client
+ * ReactNativePush plugin — ably-js's injection mechanism) and constructs the
+ * REST client.
+ */
+export function pushClient(storage: MockPushStorage, opts: PushClientOptions = {}): any {
+  const token = opts.token ?? ({ transportType: 'fcm', token: 'fcm-token-1' } as ReactNativePushToken);
+  if (opts.platform) {
+    fakeReactNative.Platform.OS = opts.platform === 'ios' ? 'ios' : 'android';
+  }
+  const plugin = ReactNativePush.create({
+    storage,
+    requestToken: opts.requestToken ?? (async () => token),
+  });
+  const clientOptions: Record<string, any> = {
+    useBinaryProtocol: false,
+    plugins: { Push: plugin },
+    ...(opts.clientOptions ?? {}),
+  };
+  if (!clientOptions.authCallback && !clientOptions.token && !clientOptions.key) {
+    clientOptions.key = 'appId.keyId:keySecret';
+  }
+  if (opts.clientId) {
+    clientOptions.clientId = opts.clientId;
+  }
+  return new Ably.Rest(clientOptions as any);
+}
+
+/**
+ * UTS `activate_into(storage, clientId?)`: runs a full activation so that
+ * `storage` holds a registered device and the persisted activation state is
+ * WaitingForNewPushDeviceDetails. Returns the client.
+ */
+export async function activateInto(storage: MockPushStorage, opts: PushClientOptions = {}): Promise<any> {
+  const client = pushClient(storage, opts);
+  await client.push.activate();
+  await waitFor(
+    () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+    'activation state to persist as WaitingForNewPushDeviceDetails',
+  );
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// polling
+
+/** Let pending microtasks/promise chains settle (UTS process_pending_events). */
+export async function flush(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+/**
+ * UTS poll_until / poll_until_success: repeatedly flush the microtask queue
+ * until the condition holds (fire-and-forget syncs and storage writes settle
+ * asynchronously).
+ */
+export async function waitFor(condition: () => boolean, description: string): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (condition()) {
+      return;
+    }
+    await flush();
+  }
+  throw new Error('timed out waiting for ' + description);
+}
+
+/** Await a promise rejection (UTS `AWAIT op() FAILS WITH error`). */
+export async function rejectionOf(promise: Promise<unknown>): Promise<any> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected promise to reject');
+}

--- a/test/uts/rest/unit/push/push_update_token.test.ts
+++ b/test/uts/rest/unit/push/push_update_token.test.ts
@@ -1,345 +1,544 @@
 /**
- * push.updateToken() tests
+ * UTS: Push updateToken Tests
  *
- * Exercises feeding a rotated FCM/APNs token into an activated device via the ReactNativePush
- * plugin, with HTTP mocked. updateToken() persists the new recipient and hands a
- * GotPushDeviceDetails event to the activation state machine (the same flow the plugin's
- * getPushDeviceDetails hook uses on activation), so the registration sync is fire-and-forget.
- * The tests cover: the registration sync (PATCH /push/deviceRegistrations/:deviceId),
- * cold-start updates from persisted state, sync failure reporting via updateFailedCallback and
- * retry, the pre-activation guard, routing through a custom registerCallback, and serialization
- * with an in-flight sync or deactivation.
+ * Exercises push.updateToken(token) (RSH2f): feeding a rotated or additional platform token
+ * into an activated device, producing the RSH8g GotPushDeviceDetails event. Covers the
+ * registration sync (PATCH /push/deviceRegistrations/:deviceId, RSH3d3b), cold-start updates
+ * from persisted state (RSH3h), sync failure reporting and retry (RSH3e3d/RSH3f1a), the
+ * RSH2f1/RSH2f2 client-side guards, routing through a custom registerCallback (RSH3d3a),
+ * serialization with an in-flight sync or deactivation (RSH4), and APNs token variants
+ * (RSH8l2/PCP3a).
+ *
+ * Spec points: RSH2f, RSH2f1, RSH2f2, RSH2f3, RSH3a2a3, RSH3a3a, RSH3d3, RSH3d3a, RSH3d3b,
+ *   RSH3d3c, RSH3d3d, RSH3e1a, RSH3e1b, RSH3e2a, RSH3e2c, RSH3e3b, RSH3e3d, RSH3f1a,
+ *   RSH3g2a, RSH3h, RSH4, RSH6a, RSH8g, RSH8l2, PCP3a, PDT4
+ * Source: specification/uts/rest/unit/push/push_update_token.md
  */
 
-import Module from 'module';
 import { expect } from 'chai';
-import { MockHttpClient } from '../../../mock_http';
-import { Ably, installMockHttp, restoreAll, flushAsync } from '../../../helpers';
-import ReactNativePush from '../../../../../src/plugins/react-native-push';
-import type { ReactNativePushToken } from '../../../../../src/plugins/react-native-push';
+import { restoreAll } from '../../../helpers';
+import {
+  installReactNativeFake,
+  restoreReactNativeFake,
+  MockPushStorage,
+  mockRegistrationServer,
+  pushClient,
+  activateInto,
+  waitFor,
+  flush,
+  rejectionOf,
+} from './push_helpers';
 
-// The plugin reads require('react-native').Platform.OS inside create(). react-native is not
-// resolvable in Node, so intercept module loading and serve this fake; tests set its OS per case.
-const fakeReactNative = { Platform: { OS: 'android' } };
-const originalModuleLoad = (Module as any)._load;
-
-/** In-memory fake of @react-native-async-storage/async-storage. */
-class FakeAsyncStorage {
-  private data = new Map<string, string>();
-
-  async getItem(key: string): Promise<string | null> {
-    return this.data.has(key) ? this.data.get(key)! : null;
-  }
-  async setItem(key: string, value: string): Promise<void> {
-    this.data.set(key, value);
-  }
-  async removeItem(key: string): Promise<void> {
-    this.data.delete(key);
-  }
-
-  // test-only synchronous accessor
-  dump(): Record<string, string> {
-    return Object.fromEntries(this.data);
-  }
-}
-
-describe('push_update_token', function () {
+describe('uts/rest/unit/push/push_update_token', function () {
   before(function () {
-    (Module as any)._load = function (request: string, ...rest: any[]) {
-      if (request === 'react-native') {
-        return fakeReactNative;
-      }
-      return originalModuleLoad.call(this, request, ...rest);
-    };
+    installReactNativeFake();
   });
 
   after(function () {
-    (Module as any)._load = originalModuleLoad;
+    restoreReactNativeFake();
   });
 
   afterEach(function () {
     restoreAll();
-    fakeReactNative.Platform.OS = 'android';
   });
 
-  function mockRegistrationServer(opts?: { onPatch?: (req: any) => void }) {
-    const captured: any[] = [];
-    const mock = new MockHttpClient({
-      onConnectionAttempt: (conn) => conn.respond_with_success(),
-      onRequest: (req) => {
-        captured.push(req);
-        if (req.method === 'post' && req.path === '/push/deviceRegistrations') {
-          req.respond_with(201, { ...JSON.parse(req.body), deviceIdentityToken: { token: 'ident-token-1' } });
-        } else if (req.method === 'patch' && req.path.startsWith('/push/deviceRegistrations/')) {
-          if (opts?.onPatch) {
-            opts.onPatch(req);
-          } else {
-            req.respond_with(200, JSON.parse(req.body));
-          }
-        } else {
-          req.respond_with(500, { error: { message: 'unexpected request ' + req.method + ' ' + req.path } });
-        }
-      },
-    });
-    installMockHttp(mock);
-    return captured;
+  // Activation as in activateInto, but as an ios/apns device (update-token-push-to-start-10)
+  async function activateIntoApns(storage: MockPushStorage): Promise<any> {
+    return activateInto(storage, { token: { transportType: 'apns', token: 'apns-token-1' }, platform: 'ios' });
   }
 
-  function rnClient(
-    storage: FakeAsyncStorage,
-    opts?: { token?: ReactNativePushToken | (() => Promise<ReactNativePushToken>) },
-  ) {
-    const token = opts?.token ?? { transportType: 'fcm' as const, token: 'fcm-token-1' };
-    return new Ably.Rest({
-      key: 'appId.keyId:keySecret',
-      useBinaryProtocol: false,
-      plugins: {
-        Push: ReactNativePush.create({
-          storage,
-          requestToken: typeof token === 'function' ? token : async () => token,
-        }),
-      },
-    });
-  }
-
-  async function rejectionOf(promise: Promise<unknown>): Promise<any> {
-    try {
-      await promise;
-    } catch (err) {
-      return err;
-    }
-    throw new Error('expected promise to reject');
-  }
-
-  // the registration sync runs fire-and-forget after updateToken() resolves, so tests poll for
-  // its observable effects rather than awaiting a promise
-  async function waitFor(condition: () => boolean, description: string): Promise<void> {
-    for (let i = 0; i < 100; i++) {
-      if (condition()) {
-        return;
-      }
-      await flushAsync();
-    }
-    throw new Error('timed out waiting for ' + description);
-  }
-
-  it('updates a rotated fcm token via PATCH and persists the new recipient', async function () {
+  /**
+   * RSH8g, RSH3d3 — delivering a rotated FCM token to an activated device produces the
+   * RSH3d3b sync: a PATCH addressed to the device, carrying only the new recipient,
+   * authenticated as the device (RSH6a), with the new recipient persisted and the machine
+   * settling back in WaitingForNewPushDeviceDetails (RSH3e2a).
+   */
+  // UTS: rest/unit/RSH3d3b/update-token-patch-0
+  it('RSH3d3b - a rotated fcm token is synced via PATCH with changed fields only', async function () {
     const captured = mockRegistrationServer();
-    const storage = new FakeAsyncStorage();
-    const client = rnClient(storage);
+    const storage = new MockPushStorage();
+    const client = await activateInto(storage);
+    const deviceId = storage.dump()['ably.push.deviceId'];
 
-    await client.push.activate();
     await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
 
+    // The sync is fire-and-forget: poll for the PATCH it issues
     await waitFor(() => captured.length === 2, 'the registration sync PATCH');
-    await flushAsync(); // let fire-and-forget storage writes settle
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
 
-    expect(captured[1].method).to.equal('patch');
-    expect(captured[1].headers.authorization).to.be.a('string'); // deviceIdentityToken bearer auth
+    const request = captured[1];
+    expect(request.method).to.equal('patch');
+    expect(request.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
 
-    const persisted = storage.dump();
-    // the device id travels in the URL; the body carries only the new recipient
-    expect(captured[1].path).to.equal('/push/deviceRegistrations/' + persisted['ably.push.deviceId']);
-    const body = JSON.parse(captured[1].body);
-    expect(body).to.deep.equal({ push: { recipient: { transportType: 'fcm', registrationToken: 'fcm-token-2' } } });
+    // RSH3d3b — only the changed fields travel in the body; the device id is in the URL
+    expect(JSON.parse(request.body)).to.deep.equal({
+      push: { recipient: { transportType: 'fcm', registrationToken: 'fcm-token-2' } },
+    });
 
-    expect(JSON.parse(persisted['ably.push.pushRecipient'])).to.deep.equal({
+    // RSH3d3b + RSH6a — push device authentication.
+    // DEVIATION(ably-js): RSH6a specifies an X-Ably-DeviceToken header carrying the
+    // deviceIdentityToken; ably-js authenticates the device with an Authorization bearer
+    // header carrying the base64 of the deviceIdentityToken (the spec's Notes permit
+    // adapting this assertion with a recorded deviation).
+    if (process.env.RUN_DEVIATIONS) {
+      expect(request.headers['X-Ably-DeviceToken']).to.equal('ident-token-1');
+    } else {
+      expect(request.headers.authorization).to.equal('Bearer ' + Buffer.from('ident-token-1').toString('base64'));
+    }
+
+    // The rotated recipient was persisted
+    expect(JSON.parse(storage.dump()['ably.push.pushRecipient'])).to.deep.equal({
       transportType: 'fcm',
       registrationToken: 'fcm-token-2',
     });
-    expect(persisted['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
   });
 
-  it('maps an apns token to an apns recipient', async function () {
+  /**
+   * RSH8g — an apns token maps to an apns recipient, whose token field is deviceToken
+   * (RSH3d3b: the PATCH body carries the changed push details).
+   */
+  // UTS: rest/unit/RSH8g/update-token-apns-recipient-1
+  it('RSH8g - an apns token maps to an apns recipient', async function () {
     const captured = mockRegistrationServer();
-    const storage = new FakeAsyncStorage();
-    fakeReactNative.Platform.OS = 'ios';
-    const client = rnClient(storage, { token: { transportType: 'apns', token: 'apns-token-1' } });
+    const storage = new MockPushStorage();
+    const client = await activateInto(storage, {
+      token: { transportType: 'apns', token: 'apns-token-1' },
+      platform: 'ios',
+    });
 
-    await client.push.activate();
     await client.push.updateToken({ transportType: 'apns', token: 'apns-token-2' });
-
     await waitFor(() => captured.length === 2, 'the registration sync PATCH');
-    const body = JSON.parse(captured[1].body);
-    expect(body.push.recipient).to.deep.equal({ transportType: 'apns', deviceToken: 'apns-token-2' });
+
+    const request = captured[1];
+    expect(request.method).to.equal('patch');
+    expect(JSON.parse(request.body)).to.deep.equal({
+      push: { recipient: { transportType: 'apns', deviceToken: 'apns-token-2' } },
+    });
   });
 
-  it('rejects when the device is not activated, and a later activation still works', async function () {
+  /**
+   * RSH2f2 — updateToken requires that the device has completed activation (has a
+   * deviceIdentityToken); otherwise it is rejected with code 40000, without any effect.
+   * The guard fires before any event reaches the state machine, so a subsequent activate()
+   * proceeds entirely normally.
+   */
+  // UTS: rest/unit/RSH2f2/update-token-requires-activation-2
+  it('RSH2f2 - updateToken requires an activated device, and does not disturb a later activation', async function () {
     const captured = mockRegistrationServer();
-    const storage = new FakeAsyncStorage();
-    const client = rnClient(storage);
+    const storage = new MockPushStorage();
+    const client = pushClient(storage);
 
     const err = await rejectionOf(client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' }));
     expect(err.code).to.equal(40000);
     expect(err.message).to.match(/not activated/);
     expect(err.remediation).to.match(/push\.activate/);
+
+    // Nothing reached the machine or the network
+    await flush();
     expect(captured).to.have.length(0);
 
-    // the guard fires before anything reaches the state machine, so activation is not affected
+    // A subsequent activation is unaffected by the rejected update
     await client.push.activate();
     expect(captured).to.have.length(1);
+    expect(captured[0].method).to.equal('post');
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
   });
 
-  it('updates from persisted state on a cold start without re-calling activate()', async function () {
+  /**
+   * RSH8g, RSH3h — a fresh client over storage holding a registered device (persisted state
+   * WaitingForNewPushDeviceDetails) can deliver a rotated token without activate() having
+   * been called this session: the machine hydrates from storage and runs the RSH3d3 sync
+   * against the persisted registration (RSH3d3b: addressed to the persisted device's id).
+   */
+  // UTS: rest/unit/RSH8g/update-token-cold-start-3
+  it('RSH8g - updateToken works from persisted state on a cold start, without activate() this session', async function () {
     const captured = mockRegistrationServer();
-    const storage = new FakeAsyncStorage();
+    const storage = new MockPushStorage();
+    await activateInto(storage);
+    const deviceId = storage.dump()['ably.push.deviceId'];
 
-    await rnClient(storage).push.activate();
-    await flushAsync();
-
-    // a fresh client over the same storage stands in for an app restart: the persisted state is
-    // WaitingForNewPushDeviceDetails, so updateToken must work without activate() this session
-    const restarted = rnClient(storage);
+    // A fresh client over the same storage simulates an app restart
+    const restarted = pushClient(storage);
     await restarted.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
-
     await waitFor(() => captured.length === 2, 'the registration sync PATCH');
-    expect(captured[1].method).to.equal('patch');
-    const body = JSON.parse(captured[1].body);
-    expect(body.push.recipient.registrationToken).to.equal('fcm-token-2');
-    // the restarted client loaded the persisted device id and addressed the same registration
-    expect(captured[1].path).to.equal('/push/deviceRegistrations/' + storage.dump()['ably.push.deviceId']);
+
+    const request = captured[1];
+    expect(request.method).to.equal('patch');
+    // The restarted client loaded the persisted device id and addressed the same registration
+    expect(request.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+    expect(JSON.parse(request.body).push.recipient.registrationToken).to.equal('fcm-token-2');
   });
 
-  it('reports a failed sync to updateFailedCallback, then a retry with the same token succeeds', async function () {
+  /**
+   * RSH3e3d, RSH3f1a — a server rejection of the sync surfaces through the update callback
+   * provided to activate() (not through updateToken, which has already resolved — the sync
+   * is fire-and-forget), the rotated recipient is nonetheless persisted, and a retry from
+   * AfterRegistrationSyncFailed re-runs the RSH3a2a validation — which per RSH3a2a3 is the
+   * same RSH3d3b PATCH sync.
+   */
+  // UTS: rest/unit/RSH3e3d/update-token-sync-failure-callback-4
+  it('RSH3e3d - a failed sync is reported via updatedCallback; a retry re-validates per RSH3a2a', async function () {
     let failPatch = true;
-    const captured = mockRegistrationServer({
-      onPatch: (req) => {
-        if (failPatch) {
-          // a 4xx response: a 5xx would additionally exercise the client's fallback-host retries
-          req.respond_with(400, { error: { message: 'server rejected sync', code: 40000, statusCode: 400 } });
-        } else {
-          req.respond_with(200, JSON.parse(req.body));
-        }
-      },
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'patch' && failPatch) {
+        req.respond_with(400, { error: { message: 'sync rejected', code: 40199, statusCode: 400 } });
+        return true;
+      }
+      return false;
     });
-    const storage = new FakeAsyncStorage();
-    const client = rnClient(storage);
-    const updateFailures: any[] = [];
-    await client.push.activate(undefined, (err) => updateFailures.push(err));
+    const storage = new MockPushStorage();
+    const client = pushClient(storage);
 
-    // the sync is fire-and-forget: updateToken resolves once the new token is persisted, and the
-    // server's rejection surfaces through the updateFailedCallback passed to activate()
+    // DEVIATION(ably-js): RSH3e3d wants failures delivered to the `updatedCallback` provided
+    // to Push#activate; ably-js only has the deprecated updateFailedCallback (RSH3e3a),
+    // taken as activate()'s second argument, so failure delivery is adapted to it here.
+    const syncResults: any[] = [];
+    await client.push.activate(undefined, (error: any) => syncResults.push(error));
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
+    const deviceId = storage.dump()['ably.push.deviceId'];
+
+    // The sync is fire-and-forget: updateToken resolves despite the PATCH failing
     await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
-    await waitFor(() => updateFailures.length === 1, 'the sync failure to reach updateFailedCallback');
-    expect(updateFailures[0].message).to.match(/server rejected sync/);
-    expect(JSON.parse(storage.dump()['ably.push.pushRecipient']).registrationToken).to.equal('fcm-token-2');
 
+    // RSH3e3d — the failure reaches the update callback
+    await waitFor(() => syncResults.length === 1, 'the sync failure to reach the update callback');
+    expect(syncResults[0].code).to.equal(40199);
+    expect(syncResults[0].message).to.match(/sync rejected/);
+
+    // The rotated recipient was persisted even though the sync failed
+    expect(JSON.parse(storage.dump()['ably.push.pushRecipient'])).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-2',
+    });
+
+    // RSH3e3b — the machine is in AfterRegistrationSyncFailed.
+    // DEVIATION(ably-js): ably-js persists only NotActivated and WaitingForNewPushDeviceDetails
+    // (isPersistentState), so the persisted state still reads WaitingForNewPushDeviceDetails
+    // even though the in-memory machine is in AfterRegistrationSyncFailed.
+    if (process.env.RUN_DEVIATIONS) {
+      await waitFor(
+        () => storage.dump()['ably.push.activationState'] === 'AfterRegistrationSyncFailed',
+        'activation state to persist as AfterRegistrationSyncFailed',
+      );
+    } else {
+      expect(storage.dump()['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
+    }
+
+    // RSH3f1a — a retry with the server healthy re-runs the RSH3a2a validation, which
+    // per RSH3a2a3 is the same RSH3d3b sync: a second PATCH with the complete recipient
     failPatch = false;
     await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
-    await waitFor(() => captured.filter((req) => req.method === 'patch').length === 2, 'the retry PATCH');
-    await flushAsync();
 
-    expect(storage.dump()['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
+    await waitFor(() => captured.filter((req) => req.method === 'patch').length === 2, 'the retry PATCH');
+    const retry = captured.filter((req) => req.method === 'patch')[1];
+    expect(retry.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+    expect(JSON.parse(retry.body).push.recipient.registrationToken).to.equal('fcm-token-2');
+
+    // RSH3e2c — the successful sync reaches the updatedCallback with no error.
+    // DEVIATION(ably-js): ably-js has no success-notification path at all (the adapted
+    // updateFailedCallback is only invoked on failure), so this assertion is guarded.
+    if (process.env.RUN_DEVIATIONS) {
+      await waitFor(() => syncResults.length === 2, 'the sync success to reach the update callback');
+      expect(syncResults[1]).to.equal(null);
+    }
+
+    // RSH3e2a — settled back in WaitingForNewPushDeviceDetails
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails after the retry',
+    );
   });
 
-  it('rejects malformed tokens without touching the machine or the network', async function () {
+  /**
+   * RSH2f1 — the provided token must carry a supported transportType and a non-empty token;
+   * an invalid token is rejected with code 40000 without any effect on the LocalDevice or
+   * the state machine: no GotPushDeviceDetails event, no HTTP request, no storage change.
+   */
+  // UTS: rest/unit/RSH2f1/update-token-validation-5
+  it('RSH2f1 - malformed tokens are rejected without touching the machine, the network, or storage', async function () {
     const captured = mockRegistrationServer();
-    const storage = new FakeAsyncStorage();
-    const client = rnClient(storage);
-    await client.push.activate();
-    await flushAsync();
+    const storage = new MockPushStorage();
+    const client = await activateInto(storage);
     const persistedBefore = storage.dump();
 
-    for (const bad of [undefined, { transportType: 'web', token: 'x' }, { transportType: 'fcm', token: '' }]) {
+    for (const bad of [
+      null,
+      undefined, // not in the UTS list; kept from the previous ably-js test's coverage
+      { transportType: 'web', token: 'web-token-1' },
+      { transportType: 'fcm', token: '' },
+    ]) {
       const err = await rejectionOf(client.push.updateToken(bad as any));
       expect(err.code).to.equal(40000);
       expect(err.message).to.match(/transportType/);
     }
 
-    await flushAsync();
+    await flush();
     expect(captured).to.have.length(1); // just the activation POST
-    expect(storage.dump()).to.deep.equal(persistedBefore);
+    expect(storage.dump()).to.deep.equal(persistedBefore); // storage untouched, recipient included
   });
 
-  it('routes the sync through a custom registerCallback supplied to activate()', async function () {
+  /**
+   * RSH3d3a — a device activated via a custom registerCallback routes the token-rotation
+   * sync through the same callback with the new recipient (instead of the PATCH of RSH3d3b),
+   * and no HTTP request is made at any point.
+   */
+  // UTS: rest/unit/RSH3d3a/update-token-register-callback-6
+  it('RSH3d3a - a device activated via a custom registerCallback syncs through the same callback', async function () {
     const captured = mockRegistrationServer();
-    const storage = new FakeAsyncStorage();
-    const client = rnClient(storage);
+    const storage = new MockPushStorage();
+    const client = pushClient(storage);
 
     const registeredRecipients: any[] = [];
-    await client.push.activate((device, callback) => {
+    await client.push.activate((device: any, callback: any) => {
       registeredRecipients.push(device.push?.recipient);
-      callback(null as any, { deviceIdentityToken: { token: 'custom-ident-1' } } as any);
+      callback(null, { deviceIdentityToken: { token: 'custom-ident-1' } });
     });
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
     expect(registeredRecipients).to.have.length(1);
-    expect(captured).to.have.length(0); // registration went through the callback
 
     await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
     await waitFor(() => registeredRecipients.length === 2, 'the sync to reach registerCallback');
-    await flushAsync();
 
-    // the device was registered through the customer's registerCallback, so the sync is routed
-    // through the same callback (with the new recipient) rather than PATCHed to Ably directly
-    expect(captured).to.have.length(0);
+    // RSH3d3a — the sync went through the same registerCallback, with the new recipient
     expect(registeredRecipients[1]).to.deep.equal({ transportType: 'fcm', registrationToken: 'fcm-token-2' });
-    expect(JSON.parse(storage.dump()['ably.push.pushRecipient']).registrationToken).to.equal('fcm-token-2');
+
+    // No HTTP at all: neither the registration nor the sync touched the network
+    expect(captured).to.have.length(0);
+
+    // The rotated recipient was persisted
+    await waitFor(
+      () => JSON.parse(storage.dump()['ably.push.pushRecipient'] ?? 'null')?.registrationToken === 'fcm-token-2',
+      'the rotated recipient to persist',
+    );
   });
 
-  it('an update issued while a sync is in flight is applied after it settles', async function () {
+  /**
+   * RSH3e1a — with the RSH3d3b PATCH held open (machine pinned in WaitingForRegistrationSync
+   * entered via GotPushDeviceDetails, RSH3d3d), an activate() resolves with no error without
+   * waiting for the sync and without issuing any request (RSH3e1b self-transition; the
+   * RSH3e1 "unless ... as a result of a CalledActivate event" carve-out does not apply here).
+   */
+  // UTS: rest/unit/RSH3e1a/activate-during-token-sync-7
+  it('RSH3e1a - activate during an in-flight token sync resolves immediately without a request', async function () {
     let heldPatch: any = null;
-    const captured = mockRegistrationServer({
-      onPatch: (req) => {
-        if (heldPatch) {
-          req.respond_with(200, JSON.parse(req.body));
-        } else {
-          heldPatch = req; // held open until the test releases it
-        }
-      },
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'patch' && !heldPatch) {
+        heldPatch = req; // hold the sync open
+        return true;
+      }
+      return false;
     });
-    const storage = new FakeAsyncStorage();
-    const client = rnClient(storage);
+    const storage = new MockPushStorage();
+    const client = await activateInto(storage);
+
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+    await waitFor(() => !!heldPatch, 'the sync PATCH'); // machine now in WaitingForRegistrationSync (RSH3d3d)
+
+    // RSH3e1a — resolves while the PATCH is still held, so it did not wait for the sync
     await client.push.activate();
+
+    // RSH3e1b — self-transition: no request was issued for the activate
+    await flush();
+    expect(captured).to.have.length(2); // activation POST + held PATCH only
+
+    heldPatch.respond_with(200, JSON.parse(heldPatch.body));
+
+    // RSH3e2a — the released sync settles the machine in WaitingForNewPushDeviceDetails
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'the released sync to settle in WaitingForNewPushDeviceDetails',
+    );
+  });
+
+  /**
+   * RSH4 — WaitingForRegistrationSync defines no transition for GotPushDeviceDetails, so the
+   * second update's event queues behind the held sync; when the first sync settles
+   * (RegistrationSynced → WaitingForNewPushDeviceDetails, RSH3e2a), the queued event is
+   * dequeued and consumed per RSH3d3, issuing its own changed-fields PATCH (RSH3d3b).
+   */
+  // UTS: rest/unit/RSH4/update-token-queued-behind-inflight-sync-8
+  it('RSH4 - an update issued during an in-flight sync is queued and applied after it settles', async function () {
+    let heldPatch: any = null;
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'patch' && !heldPatch) {
+        heldPatch = req; // hold the first sync open; later PATCHes use the default route
+        return true;
+      }
+      return false;
+    });
+    const storage = new MockPushStorage();
+    const client = await activateInto(storage);
 
     await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
     await waitFor(() => !!heldPatch, 'the first sync PATCH');
-    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-3' });
-    await flushAsync();
 
-    // the second update is queued in the state machine behind the in-flight sync
-    expect(captured.filter((req) => req.method === 'patch')).to.have.length(1);
+    // Resolves (recipient persisted, event handed over), but its sync is queued per RSH4
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-3' });
+
+    await flush();
+    expect(captured.filter((req) => req.method === 'patch')).to.have.length(1); // only the held one
 
     heldPatch.respond_with(200, JSON.parse(heldPatch.body));
     await waitFor(() => captured.filter((req) => req.method === 'patch').length === 2, 'the queued sync PATCH');
-    await flushAsync();
 
     const patches = captured.filter((req) => req.method === 'patch');
-    expect(JSON.parse(patches[1].body).push.recipient.registrationToken).to.equal('fcm-token-3');
-    expect(JSON.parse(storage.dump()['ably.push.pushRecipient']).registrationToken).to.equal('fcm-token-3');
+    expect(JSON.parse(patches[1].body)).to.deep.equal({
+      push: { recipient: { transportType: 'fcm', registrationToken: 'fcm-token-3' } },
+    });
+
+    await waitFor(
+      () => JSON.parse(storage.dump()['ably.push.pushRecipient'] ?? 'null')?.registrationToken === 'fcm-token-3',
+      'the second rotated recipient to persist',
+    );
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'WaitingForNewPushDeviceDetails',
+      'activation state to persist as WaitingForNewPushDeviceDetails',
+    );
   });
 
-  it('an update racing a deactivation is discarded once the device is deregistered', async function () {
+  /**
+   * RSH4 — WaitingForDeregistration defines no transition for GotPushDeviceDetails, so the
+   * update's event queues. Deregistration then lands the machine in NotActivated, where the
+   * dequeued event is consumed per RSH3a3a — so no sync PATCH is ever issued, and the
+   * recipient the update persisted has been cleared by RSH3g2a.
+   */
+  // UTS: rest/unit/RSH4/update-token-discarded-after-deregistration-9
+  it('RSH4 - an update racing a deactivation is discarded once the device is deregistered', async function () {
     let heldDelete: any = null;
-    const captured: any[] = [];
-    const mock = new MockHttpClient({
-      onConnectionAttempt: (conn) => conn.respond_with_success(),
-      onRequest: (req) => {
-        captured.push(req);
-        if (req.method === 'post' && req.path === '/push/deviceRegistrations') {
-          req.respond_with(201, { ...JSON.parse(req.body), deviceIdentityToken: { token: 'ident-token-1' } });
-        } else if (req.method === 'delete' && req.path === '/push/deviceRegistrations') {
-          heldDelete = req; // held open until the test releases it
-        } else {
-          req.respond_with(500, { error: { message: 'unexpected request ' + req.method + ' ' + req.path } });
-        }
-      },
+    const captured = mockRegistrationServer((req) => {
+      if (req.method === 'delete' && !heldDelete) {
+        heldDelete = req; // hold the deregistration open
+        return true;
+      }
+      return false;
     });
-    installMockHttp(mock);
-    const storage = new FakeAsyncStorage();
-    const client = rnClient(storage);
-    await client.push.activate();
+    const storage = new MockPushStorage();
+    const client = await activateInto(storage);
 
-    const deactivated = client.push.deactivate(undefined as any);
+    const deactivation = client.push.deactivate(undefined as any);
     await waitFor(() => !!heldDelete, 'the deregistration DELETE');
+
+    // The device still has its deviceIdentityToken, so the guard passes; the event queues
     await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
-    await flushAsync();
 
-    heldDelete.respond_with(200, {});
-    await deactivated;
-    await flushAsync();
+    heldDelete.respond_with(204, '');
+    await deactivation;
+    await waitFor(
+      () => storage.dump()['ably.push.activationState'] === 'NotActivated',
+      'activation state to persist as NotActivated',
+    );
 
-    // the queued sync was discarded rather than re-registering the deregistered device, and
-    // deregistration removed the recipient the update had persisted
+    // RSH4 + RSH3a3a — the queued event was consumed in NotActivated: no sync ever ran
+    await flush();
     expect(captured.filter((req) => req.method === 'patch')).to.have.length(0);
+
+    // RSH3g2a — deregistration removed the recipient the update had persisted
     expect(storage.dump()).to.not.have.property('ably.push.pushRecipient');
+  });
+
+  /**
+   * RSH8l2, PCP3a — delivering a Live Activity push-to-start token via updateToken on a
+   * device activated with a default APNs token adds the pushToStart slot to the recipient's
+   * apnsDeviceTokens map (RSH2f3) — and keeps the default token registered.
+   */
+  // UTS: rest/unit/RSH8l2/update-token-push-to-start-10
+  it('RSH8l2 - registering a push-to-start token adds a variant slot without disturbing the default token', async function () {
+    // DEVIATION(ably-js): ably-js does not implement APNs token variants (RSH8l2/PCP3a/PDT4).
+    // updateToken()'s PushDeviceToken has no apnsTokenType field; the extra property is
+    // silently ignored and the token is treated as a default apns token. Observed:
+    // updateToken({ transportType: 'apns', token: 'pts-token-1', apnsTokenType: 'pushToStart' })
+    // resolves, and the sync PATCH body is
+    // { push: { recipient: { transportType: 'apns', deviceToken: 'pts-token-1' } } } —
+    // replacing (clobbering) the default apns-token-1 recipient; no apnsDeviceTokens map exists.
+    if (!process.env.RUN_DEVIATIONS) {
+      this.skip();
+    }
+
+    const captured = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    const client = await activateIntoApns(storage);
+    const deviceId = storage.dump()['ably.push.deviceId'];
+
+    await client.push.updateToken({ transportType: 'apns', token: 'pts-token-1', apnsTokenType: 'pushToStart' });
+
+    await waitFor(() => captured.filter((req) => req.method === 'patch').length === 1, 'the registration sync PATCH');
+
+    const patch = captured.filter((req) => req.method === 'patch')[0];
+    expect(patch.path).to.equal('/push/deviceRegistrations/' + encodeURIComponent(deviceId));
+
+    const recipient = JSON.parse(patch.body).push.recipient;
+    expect(recipient.transportType).to.equal('apns');
+
+    // PCP3a — the variant landed in its slot
+    expect(recipient.apnsDeviceTokens ?? {}).to.have.property('pushToStart', 'pts-token-1');
+
+    // RSH8l2 — the default token was preserved (either representation per PCP3a)
+    expect(
+      recipient.deviceToken === 'apns-token-1' || recipient.apnsDeviceTokens?.default === 'apns-token-1',
+      'default apns token preserved',
+    ).to.equal(true);
+
+    // The full recipient, variants included, is persisted
+    const persistedRecipient = JSON.parse(storage.dump()['ably.push.pushRecipient']);
+    expect(persistedRecipient.apnsDeviceTokens ?? {}).to.have.property('pushToStart', 'pts-token-1');
+  });
+
+  /**
+   * RSH8l2 — the registration, update or removal of any single variant is a change of the
+   * push transport details, and the ensuing sync carries the complete updated recipient
+   * including the unchanged variants: rotating the default token (apnsTokenType absent —
+   * defaults to "default" per PDT4) after a pushToStart token has been registered must not
+   * drop the pushToStart slot.
+   */
+  // UTS: rest/unit/RSH8l2/update-token-variant-preserves-others-11
+  it('RSH8l2 - rotating the default token preserves registered variant slots', async function () {
+    // DEVIATION(ably-js): ably-js does not implement APNs token variants (RSH8l2/PCP3a/PDT4);
+    // see update-token-push-to-start-10. Observed: the pushToStart update replaces the whole
+    // recipient with { transportType: 'apns', deviceToken: 'pts-token-1' }, and the subsequent
+    // default-token rotation replaces it again with
+    // { transportType: 'apns', deviceToken: 'apns-token-2' } — no variant slot survives
+    // because none is ever recorded.
+    if (!process.env.RUN_DEVIATIONS) {
+      this.skip();
+    }
+
+    const captured = mockRegistrationServer();
+    const storage = new MockPushStorage();
+    const client = await activateIntoApns(storage);
+
+    await client.push.updateToken({ transportType: 'apns', token: 'pts-token-1', apnsTokenType: 'pushToStart' });
+    await waitFor(() => captured.filter((req) => req.method === 'patch').length === 1, 'the first sync PATCH');
+
+    // Rotate the default token (apnsTokenType absent — defaults to "default" per PDT4)
+    await client.push.updateToken({ transportType: 'apns', token: 'apns-token-2' });
+
+    await waitFor(() => captured.filter((req) => req.method === 'patch').length === 2, 'the second sync PATCH');
+
+    const patch = captured.filter((req) => req.method === 'patch')[1];
+    const recipient = JSON.parse(patch.body).push.recipient;
+
+    // The rotated default token
+    expect(
+      recipient.deviceToken === 'apns-token-2' || recipient.apnsDeviceTokens?.default === 'apns-token-2',
+      'rotated default apns token present',
+    ).to.equal(true);
+
+    // RSH8l2 — the pushToStart variant survived the default-token rotation
+    expect(recipient.apnsDeviceTokens ?? {}).to.have.property('pushToStart', 'pts-token-1');
+
+    const persistedRecipient = JSON.parse(storage.dump()['ably.push.pushRecipient']);
+    expect(persistedRecipient.apnsDeviceTokens ?? {}).to.have.property('pushToStart', 'pts-token-1');
   });
 });

--- a/test/uts/rest/unit/types/push_types.test.ts
+++ b/test/uts/rest/unit/types/push_types.test.ts
@@ -1,0 +1,282 @@
+/**
+ * UTS: Push Type Tests
+ *
+ * Spec points: PCD1, PCD2, PCD3, PCD4, PCD5, PCD6, PCD7, PCP1, PCP2, PCP3, PCP4,
+ *              PCS1, PCS2, PCS3, PCS4, PCS5
+ * Source: uts/rest/unit/types/push_types.md
+ *
+ * Pure type construction and serialization tests — no HTTP mock needed.
+ *
+ * Per the spec's Notes, mapped onto ably-js as follows:
+ * - The spec's `DeviceDetails.fromJson(wire)` / `device.toJson()` map to ably-js's
+ *   `DeviceDetails.fromValues(wire)` / `device.toJSON()` (likewise for
+ *   PushChannelSubscription).
+ * - Push state wire casing (PCP4): ably-js types the wire value as uppercase
+ *   ('ACTIVE' | 'FAILING' | 'FAILED') and exposes the raw wire string — there is
+ *   no DevicePushState enum. State assertions use the wire string (recorded as a
+ *   deviation per the Notes).
+ * - errorReason wire field (PCP2): ably-js's wire mapping writes the push error
+ *   as `error` under `push` (see toJSON()), and only converts a *top-level*
+ *   `error` field to ErrorInfo on fromValues — a spec-named `push.errorReason`
+ *   passes through as a plain object and is dropped by toJSON(). Guarded as
+ *   deviations.
+ * - metadata (PCD5): ably-js *types* metadata as a plain string, but fromValues
+ *   copies values as-received, so a map round-trips at runtime. The deviation is
+ *   type-level only; the runtime assertions follow the spec.
+ * - PCS5: ably-js exposes neither the forDevice/forClientId factories nor any
+ *   exactly-one enforcement (fromValues copies fields as-received). Factory
+ *   existence is guarded as a deviation; subscriptions are constructed by the
+ *   equivalent means the Notes sanction (fromValues with exactly one identifier).
+ */
+
+import { expect } from 'chai';
+import DeviceDetails, { DeviceFormFactor, DevicePlatform } from '../../../../../src/common/lib/types/devicedetails';
+import PushChannelSubscription from '../../../../../src/common/lib/types/pushchannelsubscription';
+import ErrorInfo from '../../../../../src/common/lib/types/errorinfo';
+
+describe('uts/rest/unit/types/push_types', function () {
+  /**
+   * PCD1-PCD7 - DeviceDetails round-trips all attributes through wire JSON:
+   * a full DeviceDetails parses every attribute from wire JSON, and
+   * serializing it back reproduces the same wire fields.
+   */
+  // UTS: rest/unit/PCD1/device-details-round-trip-0
+  it('PCD1-PCD7 - DeviceDetails round-trips all attributes through wire JSON', function () {
+    const wire = {
+      id: 'device-001',
+      clientId: 'client-abc',
+      platform: 'android',
+      formFactor: 'phone',
+      metadata: { environment: 'test' },
+      push: {
+        recipient: { transportType: 'fcm', registrationToken: 'reg-token-1' },
+        state: 'ACTIVE',
+        errorReason: { code: 40000, statusCode: 400, message: 'example error' },
+      },
+    };
+
+    const device = DeviceDetails.fromValues({ ...wire });
+
+    expect(device.id).to.equal('device-001'); // PCD2
+    expect(device.clientId).to.equal('client-abc'); // PCD3
+    expect(device.formFactor).to.equal(DeviceFormFactor.Phone); // PCD4
+    // PCD5 — the spec defines metadata as a map; ably-js *types* it as a string
+    // but preserves the map as-received at runtime (type-level deviation only)
+    expect(device.metadata).to.deep.equal({ environment: 'test' });
+    expect(device.platform).to.equal(DevicePlatform.Android); // PCD6
+
+    // PCD7 — push is a DevicePushDetails (PCP1). In ably-js DevicePushDetails is
+    // a structural type, not a runtime class, so assert the structure.
+    expect(device.push).to.be.an('object');
+    expect(device.push!.recipient).to.deep.equal({
+      // PCP3
+      transportType: 'fcm',
+      registrationToken: 'reg-token-1',
+    });
+    // PCP4 — ably-js exposes the raw wire string; there is no DevicePushState enum
+    expect(device.push!.state).to.equal('ACTIVE');
+    // DEVIATION(PCP2): ably-js does not parse push.errorReason as an ErrorInfo —
+    // fromValues only converts a top-level `error` field; the nested object
+    // passes through as a plain object.
+    if (process.env.RUN_DEVIATIONS) {
+      expect((device.push as any).errorReason).to.be.instanceOf(ErrorInfo);
+    }
+    expect((device.push as any).errorReason.code).to.equal(40000);
+    expect((device.push as any).errorReason.statusCode).to.equal(400);
+    expect((device.push as any).errorReason.message).to.equal('example error');
+
+    // Round trip — serialization reproduces the wire fields
+    const jsonData = device.toJSON() as any;
+    expect(jsonData.id).to.equal('device-001');
+    expect(jsonData.clientId).to.equal('client-abc');
+    expect(jsonData.platform).to.equal('android');
+    expect(jsonData.formFactor).to.equal('phone');
+    expect(jsonData.metadata).to.deep.equal({ environment: 'test' });
+    expect(jsonData.push.recipient).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'reg-token-1',
+    });
+    expect(jsonData.push.state).to.equal('ACTIVE');
+    // DEVIATION(PCP2): ably-js's toJSON() writes the push error under the wire
+    // field `error` (sourced from push.error), so a spec-named `errorReason`
+    // input is dropped from the serialized form entirely.
+    if (process.env.RUN_DEVIATIONS) {
+      expect(jsonData.push.errorReason.code).to.equal(40000);
+    }
+  });
+
+  /**
+   * PCD4 - all DeviceFormFactor values are accepted: phone, tablet, desktop,
+   * tv, watch, car, embedded, other.
+   */
+  // UTS: rest/unit/PCD4/form-factor-values-0
+  it('PCD4 - all DeviceFormFactor values are accepted', function () {
+    const formFactors = ['phone', 'tablet', 'desktop', 'tv', 'watch', 'car', 'embedded', 'other'];
+
+    for (const formFactor of formFactors) {
+      const device = DeviceDetails.fromValues({
+        id: 'device-001',
+        platform: 'android',
+        formFactor: formFactor,
+      });
+
+      // DeviceFormFactor(x) denotes the enum member whose wire value is x
+      expect(Object.values(DeviceFormFactor)).to.include(formFactor);
+      expect(device.formFactor).to.equal(formFactor);
+      expect((device.toJSON() as any).formFactor).to.equal(formFactor);
+    }
+  });
+
+  /**
+   * PCD6 - all DevicePlatform values are accepted: android, ios, browser.
+   */
+  // UTS: rest/unit/PCD6/platform-values-0
+  it('PCD6 - all DevicePlatform values are accepted', function () {
+    const platforms = ['android', 'ios', 'browser'];
+
+    for (const platform of platforms) {
+      const device = DeviceDetails.fromValues({
+        id: 'device-001',
+        platform: platform,
+        formFactor: 'phone',
+      });
+
+      // DevicePlatform(x) denotes the enum member whose wire value is x
+      expect(Object.values(DevicePlatform)).to.include(platform);
+      expect(device.platform).to.equal(platform);
+      expect((device.toJSON() as any).platform).to.equal(platform);
+    }
+  });
+
+  /**
+   * PCP2, PCP3, PCP4 - DevicePushDetails state values, errorReason, and
+   * recipient parse from wire JSON. Wire states are uppercase per ably-js's
+   * type declarations (see the spec's Notes).
+   */
+  // UTS: rest/unit/PCP4/device-push-state-values-0
+  it('PCP2, PCP3, PCP4 - DevicePushDetails state values, errorReason, and recipient parse from wire JSON', function () {
+    // The spec maps each wire state to a DevicePushState enum member
+    // (Active/Failing/Failed); ably-js has no such enum and exposes the raw
+    // wire string, so the parsed-state assertion uses the wire form (recorded
+    // as a deviation per the spec's Notes).
+    const testCases = ['ACTIVE', 'FAILING', 'FAILED'];
+
+    for (const wireState of testCases) {
+      const device = DeviceDetails.fromValues({
+        id: 'device-001',
+        platform: 'ios',
+        formFactor: 'phone',
+        push: {
+          recipient: { transportType: 'apns', deviceToken: 'apns-token-1' },
+          state: wireState,
+          errorReason: { code: 71103, statusCode: 500, message: 'upstream failure' },
+        },
+      });
+
+      // PCP4 — state parses to (ably-js: is exposed as) the wire value
+      expect(device.push!.state).to.equal(wireState);
+
+      // PCP2 — errorReason parses as ErrorInfo
+      // DEVIATION(PCP2): ably-js leaves push.errorReason as a plain object (its
+      // wire field is `error`, and no nested ErrorInfo conversion is applied).
+      if (process.env.RUN_DEVIATIONS) {
+        expect((device.push as any).errorReason).to.be.instanceOf(ErrorInfo);
+      }
+      expect((device.push as any).errorReason.code).to.equal(71103);
+
+      // PCP3 — recipient is an opaque string map, preserved as-received
+      expect(device.push!.recipient).to.deep.equal({
+        transportType: 'apns',
+        deviceToken: 'apns-token-1',
+      });
+    }
+  });
+
+  /**
+   * PCS5 - forDevice sets channel and deviceId, leaving clientId null.
+   * ably-js has no forDevice factory; the subscription is constructed by the
+   * equivalent means the spec's Notes sanction (fromValues with exactly the
+   * channel and deviceId), asserting the same exactly-one outcome.
+   */
+  // UTS: rest/unit/PCS5/push-channel-subscription-for-device-0
+  it('PCS5 - forDevice sets channel and deviceId, leaving clientId null', function () {
+    // DEVIATION(PCS5): ably-js exposes no PushChannelSubscription.forDevice factory
+    if (process.env.RUN_DEVIATIONS) {
+      expect(typeof (PushChannelSubscription as any).forDevice).to.equal('function');
+    }
+
+    const subscription = PushChannelSubscription.fromValues({
+      channel: 'push-test-channel',
+      deviceId: 'device-001',
+    });
+
+    expect(subscription.channel).to.equal('push-test-channel'); // PCS4
+    expect(subscription.deviceId).to.equal('device-001'); // PCS2
+    expect(subscription.clientId ?? null).to.equal(null); // PCS5 — the other identifier stays null
+
+    const jsonData = subscription.toJSON();
+    expect(jsonData.channel).to.equal('push-test-channel');
+    expect(jsonData.deviceId).to.equal('device-001');
+    expect(jsonData.clientId ?? null).to.equal(null);
+  });
+
+  /**
+   * PCS5 - forClientId sets channel and clientId, leaving deviceId null.
+   * ably-js has no forClientId factory; constructed by the sanctioned
+   * equivalent means (fromValues with exactly the channel and clientId).
+   */
+  // UTS: rest/unit/PCS5/push-channel-subscription-for-client-1
+  it('PCS5 - forClientId sets channel and clientId, leaving deviceId null', function () {
+    // DEVIATION(PCS5): ably-js exposes no PushChannelSubscription.forClientId factory
+    if (process.env.RUN_DEVIATIONS) {
+      expect(typeof (PushChannelSubscription as any).forClientId).to.equal('function');
+    }
+
+    const subscription = PushChannelSubscription.fromValues({
+      channel: 'push-test-channel',
+      clientId: 'client-abc',
+    });
+
+    expect(subscription.channel).to.equal('push-test-channel'); // PCS4
+    expect(subscription.clientId).to.equal('client-abc'); // PCS3
+    expect(subscription.deviceId ?? null).to.equal(null); // PCS5 — the other identifier stays null
+
+    const jsonData = subscription.toJSON();
+    expect(jsonData.channel).to.equal('push-test-channel');
+    expect(jsonData.clientId).to.equal('client-abc');
+    expect(jsonData.deviceId ?? null).to.equal(null);
+  });
+
+  /**
+   * PCS5 - precisely one of deviceId or clientId is non-null. Asserts the two
+   * portable facets: construction with one identifier leaves the other null,
+   * and a (server-invalid) wire object carrying both identifiers is handled
+   * deterministically — ably-js takes the spec's as-received branch (fromValues
+   * copies fields without validation).
+   */
+  // UTS: rest/unit/PCS5/exactly-one-of-device-client-2
+  it('PCS5 - precisely one of deviceId or clientId is non-null', function () {
+    // 1. Construction — each factory populates exactly one identifier (PCS5).
+    // DEVIATION(PCS5): ably-js has no forDevice/forClientId factories and no
+    // exactly-one enforcement; the adapted equivalent construction below shows
+    // the observable outcome (the unset identifier stays null).
+    if (process.env.RUN_DEVIATIONS) {
+      expect(typeof (PushChannelSubscription as any).forDevice).to.equal('function');
+      expect(typeof (PushChannelSubscription as any).forClientId).to.equal('function');
+    }
+    expect(PushChannelSubscription.fromValues({ channel: 'ch', deviceId: 'device-001' }).clientId ?? null).to.equal(
+      null,
+    );
+    expect(PushChannelSubscription.fromValues({ channel: 'ch', clientId: 'client-abc' }).deviceId ?? null).to.equal(
+      null,
+    );
+
+    // 2. Wire parsing — both identifiers present: reject, or expose as-received.
+    // ably-js takes branch (b): exposed as-received.
+    const wire = { channel: 'ch', deviceId: 'device-001', clientId: 'client-abc' };
+    const subscription = PushChannelSubscription.fromValues(wire);
+    expect(subscription.channel).to.equal('ch');
+    expect(subscription.deviceId).to.equal('device-001');
+    expect(subscription.clientId).to.equal('client-abc');
+  });
+});


### PR DESCRIPTION
Derives the full push activation UTS suite from the spec PR **ably/specification#513** (which adds both the push spec enhancements — `Push#updateToken`, APNs token-variant slots, the unified PATCH registration sync, the RSH6a raw-value clarification — and the portable test specs for the previously-untested activation half of RSH: RSH2, RSH3, RSH4–5, RSH6, RSH8, and the push types).

## What's here

- **`test/uts/rest/unit/push/push_helpers.ts`** — shared harness mapping the UTS push-platform constructs onto ably-js's seam: `MockPushStorage` (AsyncStorage-shaped, with `dump`/`seed`/fault flags/`onOperation`), `deferred()`, `mockRegistrationServer()`, and `pushClient()`/`activateInto()` building per-client `ReactNativePush` plugins (with the react-native module fake).
- **Unit — 62 tests, 7 files**: the full RSH3 state-machine transition matrix (both registrar branches, RSH3d2c1 classification, rollbacks), LocalDevice attributes + clientId lifecycle, persistence/rehydration incl. the RSH8a1 corruption discard, RSH4/RSH5 queue semantics (incl. the spec's own worked example), `updateToken` (existing file rewritten onto the shared harness, aligned to the updated UTS test ids, extended with the RSH8l2 token-variant tests), device auth incl. the RSH1b/RSH1c own-device clauses, and the PCD/PCP/PCS types.
- **Integration — 7 tests**: real-sandbox round-trips using ablyChannel-seeded storage (riding RSH3a2c, so no FCM/APNs credentials needed), incl. end-to-end delivery of an admin publish and the RSH6a device-auth server-acceptance check.
- **Proxy — 6 tests**: fault injection on the registration endpoints via uts-proxy — the RSH3d2c1 classifications (proven client-side by a direct admin client observing the registration survive an intercepted DELETE), rollback/retry flows, and RSH4 queueing against a delayed registration.

Every test carries its `// UTS: <test-id>` tag.

## Deviations

Tests assert spec behaviour; where ably-js is non-conformant they are skipped or assertion-guarded via the established `RUN_DEVIATIONS` convention, with **13 new entries in `test/uts/deviations.md`** documenting the observed behaviour and pointing at the exact code. Highlights (each a candidate fix PR):

- **No re-activation registration sync** (RSH3a2a/RSH3f1) — `activate()` over registered storage resolves without contacting the server; the RSH3a2a1 61002 clientId check is dead code.
- **Device auth** — a bearer `Authorization` header that *replaces* client auth (no `X-Ably-DeviceToken`; no RSH6b `X-Ably-DeviceSecret` path; and a `registerCallback` result without an identity token crashes the machine, leaving `activate()` unsettled). Live probing showed the bearer is not accepted as device auth on `/push/channelSubscriptions` — it only works on the registration endpoints because the identity token is itself an Ably token.
- Concurrent `activate()`/`deactivate()` **rejected** ("already in progress") instead of coalesced; no deregistration from `NotActivated` (RSH3a1c); RSH3d2c1 classification unimplemented; `deviceSecret` entropy below RSH3a2b's requirement; the RSH8d/e/f clientId lifecycle unwired (shares a root cause with #2192); corrupt persisted state neither discarded nor survivable (RSH3h/RSH8a1) and partial persisted state not loaded (RSH8a); `AfterRegistrationSyncFailed` not persisted; APNs token variants unimplemented (pending the spec extension); `updatedCallback` missing (only the deprecated `updateFailedCallback`); and push type-surface differences (PCP2/PCP4/PCS5).

Also corrected: the msgpack section of `deviations.md` (the limitation is this repo's JSON-level mock port, not the UTS contract — the UTS has msgpack unit specs), and a new server-issue entry for the ablyChannel-recipient PATCH bug fixed by **ably/realtime#8591** (two tests skipped unconditionally pending its sandbox deploy, then to be unskipped).

## Results

- Unit: push tier **118 passing / 18 pending**; full UTS unit suite **1428 passing / 73 pending** (`npm run test:uts:unit`).
- Integration: **6 passing / 1 pending**; proxy: **3 passing / 3 pending** (network + uts-proxy required).
- With `RUN_DEVIATIONS=1`, every skipped/guarded test fails exactly at its documented deviation point; none unexpectedly passes.

No SDK source changes in this PR — tests and deviation records only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)