### PR TITLE
fix: fall back to the base transport when websocket handshakes are rejected outright

### DIFF
--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -163,6 +163,7 @@ class ConnectionManager extends EventEmitter {
   } = { isProcessing: false, queue: [] };
   webSocketSlowTimer: NodeJS.Timeout | null;
   wsCheckResult: boolean | null;
+  wsCheckPromise: Promise<boolean> | null;
   webSocketGiveUpTimer: NodeJS.Timeout | null;
   abandonedWebSocket: boolean;
   connectCounter: number;
@@ -257,6 +258,7 @@ class ConnectionManager extends EventEmitter {
     this.forceFallbackHost = false;
     this.connectCounter = 0;
     this.wsCheckResult = null;
+    this.wsCheckPromise = null;
     this.webSocketSlowTimer = null;
     this.webSocketGiveUpTimer = null;
     this.abandonedWebSocket = false;
@@ -1046,25 +1048,25 @@ class ConnectionManager extends EventEmitter {
         'ConnectionManager WebSocket slow timer',
         'checking connectivity',
       );
-      this.checkWsConnectivity()
-        .then(() => {
+      this.checkWsConnectivityOnce().then((wsAvailable) => {
+        /* The log level has to be a literal Logger.LOG_* for the stripLogs
+         * build plugin to be able to decide whether to strip the call */
+        if (wsAvailable) {
           Logger.logAction(
             this.logger,
             Logger.LOG_MINOR,
             'ConnectionManager WebSocket slow timer',
             'ws connectivity check succeeded',
           );
-          this.wsCheckResult = true;
-        })
-        .catch(() => {
+        } else {
           Logger.logAction(
             this.logger,
             Logger.LOG_MAJOR,
             'ConnectionManager WebSocket slow timer',
             'ws connectivity check failed',
           );
-          this.wsCheckResult = false;
-        });
+        }
+      });
       if (this.realtime.http.checkConnectivity) {
         Utils.whenPromiseSettles(this.realtime.http.checkConnectivity(), (err, connectivity) => {
           if (err || !connectivity) {
@@ -1102,17 +1104,14 @@ class ConnectionManager extends EventEmitter {
   startWebSocketGiveUpTimer(transportParams: TransportParams) {
     this.webSocketGiveUpTimer = Platform.Config.setTimeout(() => {
       if (!this.wsCheckResult) {
-        Logger.logAction(
-          this.logger,
-          Logger.LOG_MINOR,
-          'ConnectionManager WebSocket give up timer',
-          'websocket connection took more than 10s; ' + (this.baseTransport ? 'trying base transport' : ''),
-        );
         if (this.baseTransport) {
-          this.abandonedWebSocket = true;
-          this.proposedTransport?.dispose();
-          this.pendingTransport?.dispose();
-          this.connectBase(transportParams, ++this.connectCounter);
+          Logger.logAction(
+            this.logger,
+            Logger.LOG_MINOR,
+            'ConnectionManager WebSocket give up timer',
+            'websocket connection took more than ' + this.options.timeouts.webSocketConnectTimeout + 'ms',
+          );
+          this.abandonWebSocketForBaseTransport(transportParams);
         } else {
           // if we don't have a base transport to fallback to, just let the websocket connection attempt time out
           Logger.logAction(
@@ -1435,6 +1434,7 @@ class ConnectionManager extends EventEmitter {
   connectWs(transportParams: TransportParams, connectCount: number) {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'ConnectionManager.connectWs()');
     this.wsCheckResult = null;
+    this.wsCheckPromise = null;
     this.abandonedWebSocket = false;
     this.startWebSocketSlowTimer();
     this.startWebSocketGiveUpTimer(transportParams);
@@ -1454,6 +1454,84 @@ class ConnectionManager extends EventEmitter {
         error: new ErrorInfo('No transports left to try', 80000, 404),
       });
     }
+  }
+
+  /* Abandon the websocket transport and connect on the base transport instead. */
+  abandonWebSocketForBaseTransport(transportParams: TransportParams): void {
+    Logger.logAction(
+      this.logger,
+      Logger.LOG_MINOR,
+      'ConnectionManager.abandonWebSocketForBaseTransport()',
+      'websocket connectivity appears to be unavailable; trying base transport',
+    );
+    this.abandonedWebSocket = true;
+    this.cancelWebSocketSlowTimer();
+    this.cancelWebSocketGiveUpTimer();
+    this.proposedTransport?.dispose();
+    this.pendingTransport?.dispose();
+    this.connectBase(transportParams, ++this.connectCounter);
+  }
+
+  /*
+   * Called when a websocket attempt has failed on every candidate host without
+   * becoming viable. The webSocketGiveUpTimer only covers websocket attempts
+   * that are *slow*; a network that rejects the upgrade outright fails every
+   * host in milliseconds, and notifying `disconnected` cancels that timer. So
+   * find out whether websockets work on this network at all before giving up.
+   *
+   * Returns whether it has taken over the connection attempt.
+   */
+  checkWsAvailabilityBeforeGivingUp(
+    transportParams: TransportParams,
+    connectCount: number,
+    giveUp: (err: IPartialErrorInfo) => void,
+  ): boolean {
+    if (!this.baseTransport || this.abandonedWebSocket) {
+      return false;
+    }
+
+    if (this.wsCheckResult) {
+      /* Websockets work here, so the hosts are at fault rather than the
+       * transport — same condition the give-up timer applies */
+      return false;
+    }
+
+    this.checkWsConnectivityOnce().then((wsAvailable) => {
+      if (connectCount !== this.connectCounter || this.abandonedWebSocket || this.state !== this.states.connecting) {
+        /* Superseded, most likely by the give-up timer */
+        return;
+      }
+      if (wsAvailable) {
+        giveUp(new ErrorInfo('Unable to connect (and no more fallback hosts to try)', 80003, 404));
+      } else {
+        this.abandonWebSocketForBaseTransport(transportParams);
+      }
+    });
+
+    /* If the check itself hangs, as on a network that silently drops
+     * handshakes, the still-running give-up timer is what moves us on */
+    return true;
+  }
+
+  /*
+   * Runs the websocket connectivity check, at most once per websocket connection
+   * attempt, recording the outcome in wsCheckResult. Never rejects; resolves to
+   * whether websocket connectivity appears to be available.
+   */
+  checkWsConnectivityOnce(): Promise<boolean> {
+    if (!this.wsCheckPromise) {
+      this.wsCheckPromise = this.checkWsConnectivity().then(
+        () => {
+          this.wsCheckResult = true;
+          return true;
+        },
+        () => {
+          this.wsCheckResult = false;
+          return false;
+        },
+      );
+    }
+    return this.wsCheckPromise;
   }
 
   tryTransportWithFallbacks(
@@ -1503,6 +1581,10 @@ class ConnectionManager extends EventEmitter {
     const tryFallbackHosts = () => {
       /* if there aren't any fallback hosts, fail */
       if (!candidateHosts.length) {
+        /* ...unless this was websocket, where the base transport may still work */
+        if (ws && this.checkWsAvailabilityBeforeGivingUp(transportParams, connectCount, giveUp)) {
+          return;
+        }
         giveUp(new ErrorInfo('Unable to connect (and no more fallback hosts to try)', 80003, 404));
         return;
       }

--- a/test/realtime/transports.test.js
+++ b/test/realtime/transports.test.js
@@ -37,6 +37,46 @@ define(['shared_helper', 'async', 'chai', 'ably'], function (Helper, async, chai
     close() {}
   }
 
+  /* Drop in replacement for WebSocket which rejects the handshake immediately,
+   * as a proxy that answers the upgrade request with (say) a 403 does: the
+   * browser surfaces that to us only as an error event followed by an unclean
+   * close. Unlike FakeWebSocket this fails fast, so the connection sequence
+   * finishes before the websocket slow/give-up timers can fire.
+   *
+   * If allowConnectivityCheck is set, the websocket connectivity check is let
+   * through, simulating a network on which websockets work but every Ably host
+   * is rejecting them. */
+  function rejectingWebSocket({ allowConnectivityCheck } = {}) {
+    return class FakeRejectingWebSocket {
+      constructor(url) {
+        this.url = url;
+        const succeed = allowConnectivityCheck && url.indexOf(originialWsCheckUrl) === 0;
+        setTimeout(() => {
+          if (succeed) {
+            if (this.onopen) this.onopen();
+            return;
+          }
+          if (this.onerror) this.onerror({ message: undefined });
+          if (this.onclose) this.onclose({ code: 1006, wasClean: false });
+        }, 0);
+      }
+      close() {}
+    };
+  }
+
+  /* Records the transports the connection manager actually attempts */
+  function recordTransportAttempts(helper, realtime) {
+    const attempts = [];
+    const connectionManager = realtime.connection.connectionManager;
+    helper.recordPrivateApi('replace.connectionManager.tryATransport');
+    const original = connectionManager.tryATransport.bind(connectionManager);
+    connectionManager.tryATransport = function (transportParams, candidate, callback) {
+      attempts.push(candidate);
+      return original(transportParams, candidate, callback);
+    };
+    return attempts;
+  }
+
   describe('realtime/transports', function () {
     this.timeout(60 * 1000);
 
@@ -113,6 +153,68 @@ define(['shared_helper', 'async', 'chai', 'ably'], function (Helper, async, chai
         helper.monitorConnection(done, realtime);
       });
 
+      /**
+       * A proxy that rejects the websocket upgrade fails every candidate host
+       * within milliseconds, so neither the websocket slow timer nor the
+       * give-up timer gets a chance to fire. The client must still work out
+       * that websockets are unusable and fall back to the base transport,
+       * rather than exhausting its fallback hosts on websocket and giving up.
+       *
+       * @nospec
+       */
+      it('ws_rejected_immediately', function (done) {
+        const helper = this.test.helper;
+        Config.WebSocket = rejectingWebSocket();
+        const realtime = helper.AblyRealtime(options(helper));
+        const attempts = recordTransportAttempts(helper, realtime);
+
+        realtime.connection.on('connected', function () {
+          try {
+            expect(realtime.connection.connectionManager.activeProtocol.transport.shortName).to.equal(
+              baseTransport(helper),
+            );
+            expect(attempts).to.include('web_socket');
+            expect(attempts[attempts.length - 1]).to.equal(baseTransport(helper));
+          } catch (err) {
+            helper.closeAndFinish(done, realtime, err);
+            return;
+          }
+          helper.closeAndFinish(done, realtime);
+        });
+
+        helper.monitorConnection(done, realtime);
+      });
+
+      /**
+       * The converse: if websockets are demonstrably available on this network
+       * then failures on every host are the hosts' problem, not the transport's,
+       * and the base transport (which talks to those same hosts) would be no
+       * better off. The client should go to disconnected and retry.
+       *
+       * @nospec
+       */
+      it('ws_rejected_immediately_but_ws_connectivity_available', function (done) {
+        const helper = this.test.helper;
+        Config.WebSocket = rejectingWebSocket({ allowConnectivityCheck: true });
+        const realtime = helper.AblyRealtime(options(helper));
+        const attempts = recordTransportAttempts(helper, realtime);
+
+        realtime.connection.once('disconnected', function (stateChange) {
+          try {
+            expect(attempts).to.not.include(baseTransport(helper));
+            expect(stateChange.reason.code).to.equal(80003, 'check code');
+          } catch (err) {
+            helper.closeAndFinish(done, realtime, err);
+            return;
+          }
+          helper.closeAndFinish(done, realtime);
+        });
+
+        realtime.connection.once('connected', function () {
+          helper.closeAndFinish(done, realtime, new Error('Connection should not have succeeded'));
+        });
+      });
+
       /** @nospec */
       it('ws_primary_host_fails', function (done) {
         const helper = this.test.helper;
@@ -142,6 +244,23 @@ define(['shared_helper', 'async', 'chai', 'ably'], function (Helper, async, chai
 
         // expect client to transition to disconnected rather than attempting base transport (which would succeed in this instance)
         realtime.connection.on('disconnected', function () {
+          helper.closeAndFinish(done, realtime);
+        });
+      });
+
+      /**
+       * With no base transport to fall back to there is nothing a websocket
+       * connectivity check could usefully tell us, so an immediately-rejected
+       * handshake must go straight to disconnected rather than waiting on one.
+       *
+       * @specpartial RTN14d
+       */
+      it('ws_rejected_immediately_with_no_base_transport', function (done) {
+        const helper = this.test.helper;
+        Config.WebSocket = rejectingWebSocket();
+        const realtime = helper.AblyRealtime({ transports: ['web_socket'] });
+
+        realtime.connection.once('disconnected', function () {
           helper.closeAndFinish(done, realtime);
         });
       });


### PR DESCRIPTION
## Problem

A browser behind a proxy that **rejects** the WebSocket upgrade — a 403, say — never connects. It rotates through its fallback hosts on `web_socket`, reports `80003 Unable to connect (and no more fallback hosts to try)`, and repeats indefinitely. `xhr_polling` is never attempted.

If the proxy instead silently *drops* the handshake, the same client connects over `xhr_polling` in ~10s. Only the fast-failure case is broken.

The failover to the base transport hangs off `webSocketGiveUpTimer` (`webSocketConnectTimeout`, 10s), which only helps when a websocket attempt is *slow*. On fast rejection, `tryFallbackHosts()` exhausts the host list in milliseconds and calls `notifyState('disconnected')` — which cancels that timer. Since 2.0 replaced connect-on-base-then-upgrade with connect-on-websocket-then-fall-back, the timers are the only route to the base transport.

## Fix

Exhausting every host on `web_socket` now runs the websocket connectivity check and decides on its result, instead of writing the attempt off:

| Connectivity check | Behaviour |
| --- | --- |
| fails | take up the base transport immediately |
| hangs | unchanged — the give-up timer takes it up at `webSocketConnectTimeout` |
| succeeds | unchanged — `disconnected`, since websockets work here and the base transport talks to the same unhealthy hosts |

That last row is what keeps `try_fallback_hosts_on_placement_constraint` passing: a client told to move datacenter must not hop back to the primary host on a different transport. It is also the condition the give-up timer already applies, so the two paths now agree.

This only affects attempts that fail on *every* host over websocket without the transport becoming viable. Clients with no base transport available skip the check entirely.

## Testing

Three new tests in `test/realtime/transports.test.js`, using a `rejectingWebSocket()` drop-in that fires `onerror` then `close(1006)` immediately — what a proxy 403 looks like to the browser WebSocket API:

- `ws_rejected_immediately` — falls back to the base transport. Times out at 60s on `main`.
- `ws_rejected_immediately_but_ws_connectivity_available` — does *not* switch transport when websockets work on the network.
- `ws_rejected_immediately_with_no_base_transport` — goes straight to `disconnected`.

All nine tests in the file pass on Chromium, Firefox and WebKit. The red CI legs are the pre-existing flaky suites (`presence`, `rest/message-operations`, `channel_backoff_*`), each verified to fail on `main` too.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time connection reliability when WebSocket connections fail during setup.
  * The app now more accurately distinguishes between unavailable connectivity and rejected connection hosts.
  * Added smoother fallback to alternative transport methods when WebSocket connections cannot be established.
  * Improved disconnected-state handling when no usable connection method is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->