### PR TITLE
Release 2.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.26.1](https://github.com/ably/ably-js/tree/2.26.1) (2026-08-10)
+
+[Full Changelog](https://github.com/ably/ably-js/compare/2.26.0...2.26.1)
+
+### What's Changed
+
+- Fall back to the base transport when a proxy rejects the WebSocket handshake outright, rather than reporting `disconnected` after exhausting every host [#2285](https://github.com/ably/ably-js/pull/2285)
+- Resumption is now decided by the server: `Connection#id`, `Connection#key` and a channel's `channelSerial` are retained through `SUSPENDED`, reconnection always attempts a resume, and the deprecated `ATTACH_RESUME` flag is no longer sent. Whether continuity was preserved is reported by the `resumed` flag on the subsequent `attached` state change [#2273](https://github.com/ably/ably-js/pull/2273)
+- Fix a resumed attach advancing the channel's attach serial, which broke the contiguity of `untilAttach` history with the realtime message stream [#2276](https://github.com/ably/ably-js/pull/2276)
+- Fix stale presence members surviving when a new presence sync replaces one still in progress [#2261](https://github.com/ably/ably-js/pull/2261)
+
 ## [2.26.0](https://github.com/ably/ably-js/tree/2.26.0) (2026-07-22)
 
 [Full Changelog](https://github.com/ably/ably-js/compare/2.25.0...2.26.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.26.0",
+      "version": "2.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -18,7 +18,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.26.0';
+export const version = '2.26.1';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
Bumps the version to 2.26.1 in `package.json`, `package-lock.json` and `src/platform/react-hooks/src/AblyReactHooks.ts`, and adds the `2.26.1` entry to `CHANGELOG.md`.

The headline change is #2285: a browser client behind a proxy that rejects the WebSocket upgrade outright never connected at all, rotating through fallback hosts on `web_socket` indefinitely instead of falling back to `xhr_polling`.

### PRs included since 2.26.0

**User-facing (in changelog)**

- #2285 (WebSocket fallback fix — headline)
- #2273 (server-side resumability)
- #2276
- #2261

**Not user-facing (not in changelog)**

- #2274 — CI
- #2278 — test-only
- #2282 — docs
- #2245 — docs
- #2244 — docs
- #2243 — docs
- #2242 — docs

#2219 merged before the 2.26.0 tag and is already in that release; #2272 is the 2.26.0 release PR itself.
