### PR TITLE
Release 2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.27.0](https://github.com/ably/ably-js/tree/2.27.0) (2026-08-10)
+
+[Full Changelog](https://github.com/ably/ably-js/compare/2.26.0...2.27.0)
+
+### What's Changed
+
+- Fall back to the base transport when a proxy rejects the WebSocket handshake outright, rather than reporting `disconnected` after exhausting every host [#2285](https://github.com/ably/ably-js/pull/2285)
+- Move connection resumability decisions from the client to the server: `Connection#id`, `Connection#key` and a channel's `channelSerial` are retained through `SUSPENDED`, and reconnection always attempts a resume. `Connection#createRecoveryKey()` consequently returns a recovery key in `SUSPENDED`, where it previously returned `null` [#2273](https://github.com/ably/ably-js/pull/2273)
+- Fix a resumed attach advancing the channel's attach serial, which broke the contiguity of `untilAttach` history with the realtime message stream [#2276](https://github.com/ably/ably-js/pull/2276)
+- Fix stale presence members surviving when a new presence sync replaces one still in progress [#2261](https://github.com/ably/ably-js/pull/2261)
+- Expand the docstrings on `Auth`, `RealtimeChannel`, `RealtimePresence`, `RealtimeAnnotations` and `RestAnnotations` to cover prerequisites, side effects and failure modes, and link the REST `Channel` and `Presence` members to their reference pages [#2242](https://github.com/ably/ably-js/pull/2242) [#2243](https://github.com/ably/ably-js/pull/2243) [#2244](https://github.com/ably/ably-js/pull/2244) [#2245](https://github.com/ably/ably-js/pull/2245) [#2282](https://github.com/ably/ably-js/pull/2282)
+
 ## [2.26.0](https://github.com/ably/ably-js/tree/2.26.0) (2026-07-22)
 
 [Full Changelog](https://github.com/ably/ably-js/compare/2.25.0...2.26.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -18,7 +18,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.26.0';
+export const version = '2.27.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
Bumps the version to 2.27.0 in `package.json`, `package-lock.json` and `src/platform/react-hooks/src/AblyReactHooks.ts`, and adds the `2.27.0` entry to `CHANGELOG.md`.

The change that drove the release is #2285: a browser client behind a proxy that rejects the WebSocket upgrade outright never connected at all, rotating through fallback hosts on `web_socket` indefinitely instead of falling back to `xhr_polling`.

A minor rather than a patch because of #2273. The public API surface is unchanged — `ably.d.ts` declarations are byte-identical to 2.26.0 once docstrings are excluded — but the resumption semantics of existing public members changed, silently as far as the type system is concerned: `Connection#id` and `Connection#key` are now retained through `SUSPENDED`, so `createRecoveryKey()` returns a key there where it previously returned `null`. The `DISCONNECTED`/`SUSPENDED` docstrings changed with it. That is adoption of spec 6.1.0, not a fix to broken behaviour, so a patch label would misdescribe it.

### PRs included since 2.26.0

**User-facing (in changelog)**

- #2285 (WebSocket fallback fix — drove the release)
- #2273 (server-side resumability — reason for the minor)
- #2276
- #2261
- #2242, #2243, #2244, #2245, #2282 (docstrings, one combined bullet)

**Not user-facing (not in changelog)**

- #2274 — CI
- #2278 — test-only

#2219 merged before the 2.26.0 tag and is already in that release; #2272 is the 2.26.0 release PR itself.
