### PR TITLE
Measure size of string fields in UTF-8 bytes for maxMessageSize accounting

### DIFF
--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -40,10 +40,10 @@ export function encodeAction(action: API.MessageAction): number {
 function getMessageSize(msg: WireMessage) {
   let size = 0;
   if (msg.name) {
-    size += msg.name.length;
+    size += Utils.dataSizeBytes(msg.name); // UTF-8 byte length
   }
   if (msg.clientId) {
-    size += msg.clientId.length;
+    size += Utils.dataSizeBytes(msg.clientId); // UTF-8 byte length
   }
   if (msg.extras) {
     size += JSON.stringify(msg.extras).length;

--- a/src/plugins/liveobjects/objectmessage.ts
+++ b/src/plugins/liveobjects/objectmessage.ts
@@ -897,7 +897,7 @@ export class WireObjectMessage {
     let size = 0;
 
     // OM3a
-    size += this.clientId?.length ?? 0; // OM3f
+    size += this.clientId ? this._utils.dataSizeBytes(this.clientId) : 0; // OM3f (UTF-8 byte length)
     if (this.operation) {
       size += this._getObjectOperationSize(this.operation); // OM3b
     }
@@ -962,7 +962,7 @@ export class WireObjectMessage {
 
     // OMP4a
     Object.entries(map.entries ?? {}).forEach(([key, entry]) => {
-      size += key?.length ?? 0; // OMP4a1
+      size += key ? this._utils.dataSizeBytes(key) : 0; // OMP4a1 (UTF-8 byte length)
       if (entry) {
         size += this._getMapEntrySize(entry); // OMP4a2
       }
@@ -1000,7 +1000,7 @@ export class WireObjectMessage {
 
     // MCR3a
     Object.entries(mapCreate.entries ?? {}).forEach(([key, entry]) => {
-      size += key?.length ?? 0; // MCR3a1
+      size += key ? this._utils.dataSizeBytes(key) : 0; // MCR3a1 (UTF-8 byte length)
       if (entry) {
         size += this._getMapEntrySize(entry); // MCR3a2
       }
@@ -1013,7 +1013,7 @@ export class WireObjectMessage {
   private _getMapSetSize(mapSet: MapSet<WireObjectData>): number {
     let size = 0;
 
-    size += mapSet.key?.length ?? 0; // MST3c
+    size += mapSet.key ? this._utils.dataSizeBytes(mapSet.key) : 0; // MST3c (UTF-8 byte length)
     if (mapSet.value) {
       size += this._getObjectDataSize(mapSet.value); // MST3b
     }
@@ -1023,7 +1023,7 @@ export class WireObjectMessage {
 
   /** @spec MRM3 */
   private _getMapRemoveSize(mapRemove: MapRemove): number {
-    return mapRemove.key.length ?? 0; // MRM3a
+    return mapRemove.key ? this._utils.dataSizeBytes(mapRemove.key) : 0; // MRM3a (UTF-8 byte length)
   }
 
   /** @spec CCR3 */

--- a/test/realtime/liveobjects.test.js
+++ b/test/realtime/liveobjects.test.js
@@ -9341,6 +9341,68 @@ define(['ably', 'shared_helper', 'chai', 'liveobjects', 'liveobjects_helper'], f
             }),
             expected: 0,
           },
+          // Non-ASCII scenarios locking the string-measurement convention: strings and keys are
+          // measured as their UTF-8 byte length, while extras is measured as the UTF-16 string
+          // length of its JSON representation. '你' is 3 UTF-8 bytes / 1 UTF-16 code unit and '😊'
+          // is 4 UTF-8 bytes / 2 UTF-16 code units, so the two measurements diverge here.
+          {
+            description: 'client id non-ascii (OM3f UTF-8 byte length)',
+            message: objectMessageFromValues({
+              clientId: '你😊',
+            }),
+            expected: Utils.dataSizeBytes('你😊'),
+          },
+          {
+            description: 'map create op key non-ascii (MCR3a1 UTF-8 byte length)',
+            message: objectMessageFromValues({
+              operation: {
+                action: 0,
+                objectId: 'object-id',
+                mapCreate: { semantics: 0, entries: { '你😊': { tombstone: false, data: { string: 'a string' } } } },
+              },
+            }),
+            expected: Utils.dataSizeBytes('你😊') + Utils.dataSizeBytes('a string'),
+          },
+          {
+            description: 'map set op key non-ascii (MST3c UTF-8 byte length)',
+            message: objectMessageFromValues({
+              operation: { action: 1, objectId: 'object-id', mapSet: { key: '你😊', value: { string: 'my-value' } } },
+            }),
+            expected: Utils.dataSizeBytes('你😊') + Utils.dataSizeBytes('my-value'),
+          },
+          {
+            description: 'map remove op key non-ascii (MRM3a UTF-8 byte length)',
+            message: objectMessageFromValues({
+              operation: { action: 2, objectId: 'object-id', mapRemove: { key: '你😊' } },
+            }),
+            expected: Utils.dataSizeBytes('你😊'),
+          },
+          {
+            description: 'map object entry key non-ascii (OMP4a1 UTF-8 byte length)',
+            message: objectMessageFromValues({
+              object: {
+                objectId: 'object-id',
+                map: {
+                  semantics: 0,
+                  entries: {
+                    '你😊': { tombstone: false, data: { string: 'a string' } },
+                  },
+                },
+                siteTimeserials: { aaa: lexicoTimeserial('aaa', 111, 111, 1) }, // shouldn't be counted
+                tombstone: false,
+              },
+            }),
+            expected: Utils.dataSizeBytes('你😊') + Utils.dataSizeBytes('a string'),
+          },
+          {
+            description: 'extras non-ascii (OM3d UTF-16 string length of JSON)',
+            message: objectMessageFromValues({
+              extras: { foo: '你😊' },
+            }),
+            // extras keeps the docs-verbatim "string length of its JSON representation" (UTF-16
+            // code units), not the UTF-8 byte length used for the fields above.
+            expected: JSON.stringify({ foo: '你😊' }).length,
+          },
         ];
 
         /** @nospec */


### PR DESCRIPTION
## Problem

The client-side `maxMessageSize` publish gate sums per-field sizes and rejects an over-limit publish before it hits the wire. ably-js measured string fields (`clientId`, LiveObjects map/operation keys) by their **UTF-16 code-unit count** (`.length`), but the server accounts for these fields in **UTF-8 bytes**. For ASCII these coincide; for non-ASCII they diverge (`你` = 3 UTF-8 bytes / 1 UTF-16 code unit; `😊` = 4 UTF-8 bytes / 2 UTF-16 code units), so js **undercounted**.

Ably's published accounting — **[How is maximum message size measured?](https://ably.com/docs/pricing/faqs)** — is explicit:

> **name and clientId:** *"calculated as the size in bytes of their UTF-8 representation"*
> **data:** *"calculated as the size in bytes if it is in binary, or its UTF-8 byte length if it is a string"*
> **extras:** *"calculated as the string length of its JSON representation"*

Consequences of the undercount:

- **False-accepts.** A boundary message whose UTF-16 count sat under the limit but whose UTF-8 byte count is over would pass the local gate and get **asynchronously NACKed by the server** (`40009`/`40006`) — or drop the connection — instead of being cleanly rejected locally.
- **Cross-SDK gate divergence.** The same `clientId`/key was accepted by js but rejected by ably-java / ably-cocoa (which already counted UTF-8) — one publish, two verdicts.

Spec disambiguation (anchor PR): **https://github.com/ably/specification/pull/516**. History / earlier attempt: [ably/specification#331](https://github.com/ably/specification/pull/331).

## Solution

Measure string fields in UTF-8 bytes via the existing `Utils.dataSizeBytes` (`TextEncoder` / `Buffer.byteLength`), matching the server. `extras` is deliberately **unchanged** — the published accounting has an explicit distinct rule for it ("string length of its JSON representation", i.e. UTF-16 code units), and measuring `extras` in UTF-8 would over-count and false-reject documented-valid messages.

Sites changed:

- **`src/plugins/liveobjects/objectmessage.ts`** — 5 sites `?.length` → `dataSizeBytes(...)`: `clientId` (OM3f), `OMP4a1` (map-state key), `MCR3a1`, `MST3c`, `MRM3a` (operation keys). `extras` stays `JSON.stringify(...).length`; `ObjectData` (OD3b–g) already used `dataSizeBytes`.
- **`src/common/lib/types/message.ts`** (`getMessageSize`) — `name` and `clientId` `.length` → `Utils.dataSizeBytes(...)` (UTF-8). `extras` stays `JSON.stringify(...).length`.

## Tests

`test/realtime/liveobjects.test.js` — +6 non-ASCII `ObjectMessage` size scenarios (`clientId = '你😊'` etc.) locking the convention: `OM3f`/`MCR3a1`/`MST3c`/`MRM3a`/`OMP4a1` asserted against `Utils.dataSizeBytes(...)` (UTF-8), `OM3d` (extras) asserted against `JSON.stringify(...).length` (UTF-16).

## Verification

- `npm run build:node` — clean.
- `npx tsc --noEmit -p tsconfig.json` — 0 errors.
- `mocha test/realtime/liveobjects.test.js --grep "message size"` — **37 passing** (incl. the 6 new non-ASCII scenarios).

## Notes

Follow-up: the `name`/`clientId` UTF-8 change in `getMessageSize` (regular `Message`) has no dedicated non-ASCII unit test yet — the new scenarios cover the LiveObjects `ObjectMessage` path only. Worth adding one alongside the regular-Message size tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected message size calculations to accurately account for UTF-8 byte lengths in client IDs, map keys, and object entries.
  * Improved size reporting for messages containing non-ASCII characters.

* **Tests**
  * Added coverage for Unicode client IDs, map keys, object entries, and extra data to verify accurate size calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->