### PR TITLE
Report error 92000 with HTTP status 400, not 500

### DIFF
--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -105,7 +105,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
       throw new this._client.ErrorInfo(
         `Cannot apply object operation with objectId=${op.objectId}, to this LiveCounter with objectId=${this.getObjectId()}`,
         92000,
-        500,
+        400,
       );
     }
 
@@ -180,14 +180,14 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
   overrideWithObjectState(objectMessage: ObjectMessage): LiveCounterUpdate | LiveObjectUpdateNoop {
     const objectState = objectMessage.object;
     if (objectState == null) {
-      throw new this._client.ErrorInfo(`Missing object state; LiveCounter objectId=${this.getObjectId()}`, 92000, 500);
+      throw new this._client.ErrorInfo(`Missing object state; LiveCounter objectId=${this.getObjectId()}`, 92000, 400);
     }
 
     if (objectState.objectId !== this.getObjectId()) {
       throw new this._client.ErrorInfo(
         `Invalid object state: object state objectId=${objectState.objectId}; LiveCounter objectId=${this.getObjectId()}`,
         92000,
-        500,
+        400,
       );
     }
 
@@ -197,7 +197,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
         throw new this._client.ErrorInfo(
           `Invalid object state: object state createOp objectId=${objectState.createOp?.objectId}; LiveCounter objectId=${this.getObjectId()}`,
           92000,
-          500,
+          400,
         );
       }
 
@@ -205,7 +205,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
         throw new this._client.ErrorInfo(
           `Invalid object state: object state createOp action=${objectState.createOp?.action}; LiveCounter objectId=${this.getObjectId()}`,
           92000,
-          500,
+          400,
         );
       }
     }

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -301,7 +301,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       throw new this._client.ErrorInfo(
         `Cannot apply object operation with objectId=${op.objectId}, to this LiveMap with objectId=${this.getObjectId()}`,
         92000,
-        500,
+        400,
       );
     }
 
@@ -390,14 +390,14 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
   overrideWithObjectState(objectMessage: ObjectMessage): LiveMapUpdate<T> | LiveObjectUpdateNoop {
     const objectState = objectMessage.object;
     if (objectState == null) {
-      throw new this._client.ErrorInfo(`Missing object state; LiveMap objectId=${this.getObjectId()}`, 92000, 500);
+      throw new this._client.ErrorInfo(`Missing object state; LiveMap objectId=${this.getObjectId()}`, 92000, 400);
     }
 
     if (objectState.objectId !== this.getObjectId()) {
       throw new this._client.ErrorInfo(
         `Invalid object state: object state objectId=${objectState.objectId}; LiveMap objectId=${this.getObjectId()}`,
         92000,
-        500,
+        400,
       );
     }
 
@@ -405,7 +405,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       throw new this._client.ErrorInfo(
         `Invalid object state: object state map semantics=${objectState.map?.semantics}; LiveMap semantics=${this._semantics}`,
         92000,
-        500,
+        400,
       );
     }
 
@@ -415,7 +415,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
         throw new this._client.ErrorInfo(
           `Invalid object state: object state createOp objectId=${objectState.createOp?.objectId}; LiveMap objectId=${this.getObjectId()}`,
           92000,
-          500,
+          400,
         );
       }
 
@@ -423,7 +423,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
         throw new this._client.ErrorInfo(
           `Invalid object state: object state createOp action=${objectState.createOp?.action}; LiveMap objectId=${this.getObjectId()}`,
           92000,
-          500,
+          400,
         );
       }
 
@@ -431,7 +431,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
         throw new this._client.ErrorInfo(
           `Invalid object state: object state createOp map semantics=${objectState.createOp.mapCreate?.semantics}; LiveMap semantics=${this._semantics}`,
           92000,
-          500,
+          400,
         );
       }
     }
@@ -738,7 +738,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       throw new this._client.ErrorInfo(
         `Cannot apply MAP_CREATE op on LiveMap objectId=${this.getObjectId()}; map's semantics=${this._semantics}, but op expected ${mapCreate?.semantics}`,
         92000,
-        500,
+        400,
       );
     }
 
@@ -781,7 +781,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       throw new ErrorInfo(
         `Invalid object data for MAP_SET op on objectId=${this.getObjectId()} on key="${op.key}"`,
         92000,
-        500,
+        400,
       );
     }
 

--- a/src/plugins/liveobjects/objectid.ts
+++ b/src/plugins/liveobjects/objectid.ts
@@ -50,26 +50,26 @@ export class ObjectId {
    */
   static fromString(client: BaseClient, objectId: string | null | undefined): ObjectId {
     if (client.Utils.isNil(objectId)) {
-      throw new client.ErrorInfo('Invalid object id string', 92000, 500);
+      throw new client.ErrorInfo('Invalid object id string', 92000, 400);
     }
 
     // RTO6b1
     const [type, rest] = objectId.split(':');
     if (!type || !rest) {
-      throw new client.ErrorInfo('Invalid object id string', 92000, 500);
+      throw new client.ErrorInfo('Invalid object id string', 92000, 400);
     }
 
     if (!['map', 'counter'].includes(type)) {
-      throw new client.ErrorInfo(`Invalid object type in object id: ${objectId}`, 92000, 500);
+      throw new client.ErrorInfo(`Invalid object type in object id: ${objectId}`, 92000, 400);
     }
 
     const [hash, msTimestamp] = rest.split('@');
     if (!hash || !msTimestamp) {
-      throw new client.ErrorInfo('Invalid object id string', 92000, 500);
+      throw new client.ErrorInfo('Invalid object id string', 92000, 400);
     }
 
     if (!Number.isInteger(Number.parseInt(msTimestamp))) {
-      throw new client.ErrorInfo('Invalid object id string', 92000, 500);
+      throw new client.ErrorInfo('Invalid object id string', 92000, 400);
     }
 
     return new ObjectId(type as LiveObjectType, hash, Number.parseInt(msTimestamp));


### PR DESCRIPTION
Stacked on #2281 — base is `error-codes`, so the diff here is just the 19 lines.

## Why

Registry [`errors/codes/92000.md`](https://github.com/ably/ably-common/blob/main/errors/codes/92000.md) documents `invalid_object_message` as **HTTP 400**:

> The error is reported with code 92000 and HTTP status 400.

Every site raising it in the LiveObjects plugin is a caller-side fault — a malformed object id, an `objectId` that doesn't match the object it's applied to, or an object state that doesn't conform to the expected structure. A 500 tells the caller Ably failed, pointing them at support rather than at the operation they built.

The sibling codes raised in these same files already use 400, so 92000 was the odd one out:

| Code | statusCode used | |
| --- | --- | --- |
| 92000 | **500** | 19 sites — this PR |
| 92005 | 400 | already correct |
| 92007 | 400 | already correct |
| 92008 | 400 | already correct |

## Why #2281 doesn't catch it

The `ErrorCode` union constrains the `code` argument but leaves `statusCode` a bare `number`, so a wrong status stays invisible to the compiler. Both of these still compile on `error-codes`:

```ts
new ErrorInfo('x', 40000, 40000);   // a code in the statusCode slot
new ErrorInfo('x', 40000, 999);     // not an HTTP status at all
```

Worth considering typing `statusCode` too — `src/common/constants/HttpStatusCodes.ts` already exists as prior art.

## Scope

19 sites, status argument only:

- `src/plugins/liveobjects/livemap.ts` — 9
- `src/plugins/liveobjects/livecounter.ts` — 5
- `src/plugins/liveobjects/objectid.ts` — 5

## Verification

- `npx tsc --noEmit -p tsconfig.json` — 0 errors
- No test asserts code 92000 or its status anywhere in `test/`
- `git diff --numstat` is 5/5, 9/9, 5/5 — no incidental changes

## Note

This is a user-visible change: `error.statusCode` on these throws goes 500 → 400. The `code` is unchanged, and nothing in the SDK branches on the status for these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP responses for invalid object IDs, object states, map data, and operation details.
  * Client-side validation errors now return HTTP 400 instead of HTTP 500.
  * Preserved existing error codes and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->