### PR TITLE
Release 2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.28.0](https://github.com/ably/ably-js/tree/2.28.0) (2026-08-21)
+
+[Full Changelog](https://github.com/ably/ably-js/compare/2.27.0...2.28.0)
+
+### What's Changed
+
+- Roll out e2e encryption of `data` payloads on annotations. They were previously a message type whose publish path deliberately did not apply the channel's encryption (and were documented accordingly), but the reasons for this no longer apply, so there is no reason now not to enable e2e encryption on annotation payloads. [#2277](https://github.com/ably/ably-js/pull/2277)
+
 ## [2.27.0](https://github.com/ably/ably-js/tree/2.27.0) (2026-08-10)
 
 [Full Changelog](https://github.com/ably/ably-js/compare/2.26.0...2.27.0)

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2545,7 +2545,7 @@ export declare interface RealtimeAnnotations {
    *
    * Does not implicitly attach the channel. It rejects with an {@link ErrorInfo} on a channel in the `failed` or `suspended` state, or when the connection is unusable.
    *
-   * Annotation data is never encrypted, even when {@link ChannelOptions.cipher} is set, because the server must be able to read it to build summaries.
+   * Annotation data is encrypted when {@link ChannelOptions.cipher} is set, as it is for messages and presence messages.
    *
    * @param message - The message to annotate.
    * @param annotation - The annotation to publish. It must include at least the `type`. Other required fields depend on the annotation type.
@@ -2566,7 +2566,7 @@ export declare interface RealtimeAnnotations {
    *
    * Does not implicitly attach the channel. It rejects with an {@link ErrorInfo} on a channel in the `failed` or `suspended` state, or when the connection is unusable.
    *
-   * Annotation data is never encrypted, even when {@link ChannelOptions.cipher} is set, because the server must be able to read it to build summaries.
+   * Annotation data is encrypted when {@link ChannelOptions.cipher} is set, as it is for messages and presence messages.
    *
    * @param messageSerial - The serial field of the message to annotate.
    * @param annotation - The annotation to publish. It must include at least the `type`. Other required fields depend on the annotation type.
@@ -2864,7 +2864,7 @@ export declare interface RestAnnotations {
    *
    * Message annotations must be enabled for the channel's namespace by a [rule](https://ably.com/docs/messages/annotations), and the key or token must have the `annotation-publish` capability. Without either the server rejects the operation, so the call rejects with an {@link ErrorInfo}.
    *
-   * Annotation data is never encrypted, even when {@link ChannelOptions.cipher} is set, because the server must be able to read it to build summaries.
+   * Annotation data is encrypted when {@link ChannelOptions.cipher} is set, as it is for messages and presence messages.
    *
    * @param message - The message to annotate.
    * @param annotation - The annotation to publish. It must include at least the `type`. Other required fields depend on the annotation type.
@@ -2883,7 +2883,7 @@ export declare interface RestAnnotations {
    *
    * Message annotations must be enabled for the channel's namespace by a [rule](https://ably.com/docs/messages/annotations), and the key or token must have the `annotation-publish` capability. Without either the server rejects the operation, so the call rejects with an {@link ErrorInfo}.
    *
-   * Annotation data is never encrypted, even when {@link ChannelOptions.cipher} is set, because the server must be able to read it to build summaries.
+   * Annotation data is encrypted when {@link ChannelOptions.cipher} is set, as it is for messages and presence messages.
    *
    * @param messageSerial - The serial field of the message to annotate.
    * @param annotation - The annotation to publish. It must include at least the `type`. Other required fields depend on the annotation type.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.27.0",
+      "version": "2.28.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -18,7 +18,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.27.0';
+export const version = '2.28.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
Bumps the version to 2.28.0 in `package.json`, `package-lock.json` and `src/platform/react-hooks/src/AblyReactHooks.ts`, and adds the `2.28.0` entry to `CHANGELOG.md`.

The change that drove the release is #2277: annotation `data` payloads were published in plaintext even on channels with a cipher configured, because `Annotation.encode()` passed an empty options object to the shared `encode()` helper. Annotations were the only message type whose publish path did not apply the channel's encryption.

Also included is a docstring correction that #2277 should have carried. The four `publish` docstrings on `RealtimeAnnotations` and `RestAnnotations` stated that annotation data is never encrypted, and gave the server's need to read it for summarisation as the reason. Both halves stopped being true once #2277 landed, and the reason had been stale considerably longer — see below.

### Why a minor rather than a patch

Not for wire compatibility: the decode path already passed `channelOptions` through before #2277, so the change is one-directional and compatible both ways. A 2.27.0 subscriber decrypts an annotation published by 2.28.0, and a 2.28.0 subscriber handles a plaintext annotation from an older publisher unchanged.

The reason is that the old behaviour was documented in `ably.d.ts`, so anything built against that documented guarantee — a server-side integration parsing annotation `data` on a ciphered channel — now receives ciphertext. A patch is the release people apply without reading the changelog.

Worth recording that the documented rationale was already obsolete. The server needed to read `data` only for `multiple.v1` as originally imagined, which used payloads like `{"count":1}`. That API was changed before annotations went public, specifically so aggregation did not read payloads, preserving the "Ably never reads your payload" property and making end-to-end encryption possible. That landed in ably-js in April 2025 with the `count` field, but enabling encryption was missed at the time. Summarisation reads `type`/`name`/`count` and never `data`, so encrypting it costs nothing server-side.

### PRs included since 2.27.0

**User-facing (in changelog)**

- #2277 (annotation payload encryption — drove the release)

The branch also carries an internal replacement of `CipherOptions` with an `EncryptedChannelOptions` type narrowed by an `isEncrypted()` guard, a fix for `encode()` testing `cipher` without `channelCipher` before dereferencing it, and removal of some anti-flake sleeps from the annotation tests. None are user-facing, and all merged as part of #2277 rather than separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Annotation data payloads are now protected with end-to-end encryption when channel encryption is configured, across realtime and REST publishing.
  * This provides stronger privacy for annotation content during transmission.
* **Documentation**
  * Updated annotation publishing and deletion guidance to reflect encrypted payload support.
  * Added release notes for version 2.28.0, including a link to the complete changelog.
* **Release**
  * Updated the package and React hooks version to 2.28.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->