### PR TITLE
Update repository references for rename to ably-pubsub-js

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-js
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-pubsub-js
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
       - uses: ably/sdk-upload-action@8c6179796fc7ee8fc9bb28d5223ffef005b985cc # v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-js
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-pubsub-js
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
 
       - name: Upload Documentation

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -14,6 +14,6 @@ jobs:
       id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
-      repository-name: ably-js
+      repository-name: ably-pubsub-js
     secrets:
       ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-ably-js.iml
+ably-pubsub-js.iml
 .idea
 node_modules
 npm-debug.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to ably-js
+# Contributing to ably-pubsub-js
 
 ## Contributing
 
@@ -7,7 +7,7 @@
 3. Create your feature branch (`git checkout -b my-new-feature`)
 4. Commit your changes (`git commit -am 'Add some feature'`)
 5. Ensure you have added suitable tests and the test suite is passing(`npm test`)
-6. Ensure the [type definitions](https://github.com/ably/ably-js/blob/main/ably.d.ts) have been updated if the public API has changed
+6. Ensure the [type definitions](https://github.com/ably/ably-pubsub-js/blob/main/ably.d.ts) have been updated if the public API has changed
 7. Push the branch (`git push origin my-new-feature`)
 8. Create a new Pull Request
 
@@ -23,7 +23,7 @@
 8. Run `git tag <VERSION_NUMBER>` with the new version and push the tag to GitHub with `git push <REMOTE> <VERSION_NUMBER>` (usually `git push origin <VERSION_NUMBER>`)
 9. Run `npm publish .` (should require OTP) - publishes to NPM
 10. Run the GitHub action "Publish to CDN" with the new tag name
-11. Visit https://github.com/ably/ably-js/tags and create a GitHub release based on the new tag (for release notes, you generally can just copy the notes you added to the CHANGELOG)
+11. Visit https://github.com/ably/ably-pubsub-js/tags and create a GitHub release based on the new tag (for release notes, you generally can just copy the notes you added to the CHANGELOG)
 12. Update the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/)) with these changes (again, you can just copy the notes you added to the CHANGELOG)
 
 ## Building the library

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Ably Chat Header](/images/JavaScriptSDK-github.png)
 [![npm version](https://img.shields.io/npm/v/ably.svg?style=flat)](https://img.shields.io/npm/v/ably.svg?style=flat)
-[![License](https://badgen.net/github/license/ably/ably-js)](https://github.com/ably/ably-js/blob/main/LICENSE)
+[![License](https://badgen.net/github/license/ably/ably-pubsub-js)](https://github.com/ably/ably-pubsub-js/blob/main/LICENSE)
 
 ---
 
@@ -38,7 +38,7 @@ The following platforms are supported:
 | Platform    | Support                                                                                  |
 | ----------- | ---------------------------------------------------------------------------------------- |
 | JavaScript  | ES2017                                                                                   |
-| Node.js     | See `engines` in [package.json](https://github.com/ably/ably-js/blob/main/package.json). |
+| Node.js     | See `engines` in [package.json](https://github.com/ably/ably-pubsub-js/blob/main/package.json). |
 | React       | >=16.8.x                                                                                 |
 | TypeScript  | Type definitions are included in the package.                                            |
 | Web Workers | Browser bundle and [modular](#modular-variant) support.                                  |
@@ -133,7 +133,7 @@ In order to further reduce bundle size, the modular variant of the SDK performs 
 
 If you require more verbose logging, use the default variant of the SDK.
 
-For more information view the [TypeDoc references](https://sdk.ably.com/builds/ably/ably-js/main/typedoc/modules/modular.html).
+For more information view the [TypeDoc references](https://sdk.ably.com/builds/ably/ably-pubsub-js/main/typedoc/modules/modular.html).
 
 </details>
 
@@ -147,13 +147,13 @@ Read the [CONTRIBUTING.md](./CONTRIBUTING.md) guidelines to contribute to Ably.
 
 ## Releases
 
-The [CHANGELOG.md](/ably/ably-js/blob/main/CHANGELOG.md) contains details of the latest releases for this SDK. You can also view all Ably releases on [changelog.ably.com](https://changelog.ably.com).
+The [CHANGELOG.md](/ably/ably-pubsub-js/blob/main/CHANGELOG.md) contains details of the latest releases for this SDK. You can also view all Ably releases on [changelog.ably.com](https://changelog.ably.com).
 
 ---
 
 ## Support, feedback, and troubleshooting
 
-For help or technical support, visit Ably's [support page](https://ably.com/support) or [GitHub Issues](https://github.com/ably/ably-js-nativescript/issues) for community-reported bugs and discussions.
+For help or technical support, visit Ably's [support page](https://ably.com/support) or [GitHub Issues](https://github.com/ably/ably-pubsub-js/issues) for community-reported bugs and discussions.
 
 ### Chrome extensions
 
@@ -221,7 +221,7 @@ export default function AblyClientProvider({ children }) {
 }
 ```
 
-Avoid creating the client inside [React](https://github.com/ably/ably-js/blob/main/docs/react.md#Usage) component bodies, as this leads to a new connection on every render. Use the `useEffect` + `useState` pattern shown above, or move the client to a shared provider at the layout level.
+Avoid creating the client inside [React](https://github.com/ably/ably-pubsub-js/blob/main/docs/react.md#Usage) component bodies, as this leads to a new connection on every render. Use the `useEffect` + `useState` pattern shown above, or move the client to a shared provider at the layout level.
 
 In development environments that use Hot Module Replacement (HMR), such as React, Vite, or Next.js, saving a file can recreate the Ably.Realtime client, while previous instances remain connected. Over time, this leads to a growing number of active connections with each code edit. To fix: Move the client to a separate file (e.g., `ably-client.js`) and import it. This ensures the client is recreated only when that file changes.
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Ably aims to support a wide range of platforms and all current browser versions,
 
 The following platforms are supported:
 
-| Platform    | Support                                                                                  |
-| ----------- | ---------------------------------------------------------------------------------------- |
-| JavaScript  | ES2017                                                                                   |
+| Platform    | Support                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------- |
+| JavaScript  | ES2017                                                                                          |
 | Node.js     | See `engines` in [package.json](https://github.com/ably/ably-pubsub-js/blob/main/package.json). |
-| React       | >=16.8.x                                                                                 |
-| TypeScript  | Type definitions are included in the package.                                            |
-| Web Workers | Browser bundle and [modular](#modular-variant) support.                                  |
+| React       | >=16.8.x                                                                                        |
+| TypeScript  | Type definitions are included in the package.                                                   |
+| Web Workers | Browser bundle and [modular](#modular-variant) support.                                         |
 
 > [!NOTE]
 > Versions 1.2.x of the SDK support Internet Explorer >=9 and other older browsers, as well as Node.js >=8.17.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.28.0",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ably/ably-js/issues",
+    "url": "https://github.com/ably/ably-pubsub-js/issues",
     "email": "support@ably.com"
   },
   "main": "./build/ably-node.js",
@@ -164,7 +164,7 @@
   "engines": {
     "node": ">=16"
   },
-  "repository": "ably/ably-js",
+  "repository": "ably/ably-pubsub-js",
   "jspm": {
     "registry": "npm",
     "directories": {

--- a/scripts/processPrivateApiData/utils.ts
+++ b/scripts/processPrivateApiData/utils.ts
@@ -5,7 +5,7 @@ import { StaticContext } from './staticContext';
 export function stripFilePrefix(records: Record[]) {
   for (const record of records) {
     if (record.context.file !== null) {
-      record.context.file = record.context.file.replace('/home/runner/work/ably-js/ably-js/', '');
+      record.context.file = record.context.file.replace('/home/runner/work/ably-pubsub-js/ably-pubsub-js/', '');
     }
   }
 }

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -525,7 +525,7 @@ export function createMissingPluginError(pluginName: keyof ModularPlugins): Erro
         'Import { LiveObjects } from "ably/liveobjects" and pass it in ClientOptions.plugins: { LiveObjects }.';
       break;
     default:
-      remediation = `Import ${pluginName} from "ably/modular" and pass it in ClientOptions.plugins: { ${pluginName} }. See the modular variant reference at https://sdk.ably.com/builds/ably/ably-js/main/typedoc/modules/modular.html.`;
+      remediation = `Import ${pluginName} from "ably/modular" and pass it in ClientOptions.plugins: { ${pluginName} }. See the modular variant reference at https://sdk.ably.com/builds/ably/ably-pubsub-js/main/typedoc/modules/modular.html.`;
       break;
   }
   const err = new ErrorInfo({

--- a/src/fragments/license.js
+++ b/src/fragments/license.js
@@ -4,6 +4,6 @@ const { version } = require('../../package.json');
 module.exports = `@license Copyright 2015-2022 Ably Real-time Ltd (ably.com)
 
 Ably JavaScript Library v${version}
-https://github.com/ably/ably-js
+https://github.com/ably/ably-pubsub-js
 
 Released under the Apache Licence v2.0`;

--- a/typedoc/landing-page.md
+++ b/typedoc/landing-page.md
@@ -1,6 +1,6 @@
 # Ably JavaScript Client Library SDK API Reference
 
-The JavaScript Client Library SDK supports a realtime and a REST interface. The JavaScript API references are generated from the [Ably JavaScript Client Library SDK source code](https://github.com/ably/ably-js/) using [TypeDoc](https://typedoc.org) and structured by classes.
+The JavaScript Client Library SDK supports a realtime and a REST interface. The JavaScript API references are generated from the [Ably JavaScript Client Library SDK source code](https://github.com/ably/ably-pubsub-js/) using [TypeDoc](https://typedoc.org) and structured by classes.
 
 The realtime interface enables a client to maintain a persistent connection to Ably and publish, subscribe and be present on channels. The REST interface is stateless and typically implemented server-side. It is used to make requests such as retrieving statistics, token authentication and publishing to a channel.
 


### PR DESCRIPTION
**Do not merge until the repository is renamed `ably-js` → `ably-pubsub-js`, in the programme's rename freeze window.** Merging early points `docs.yml`, `bundle-report.yml` and `features.yml` at the `ably-sdk-builds-ably-pubsub-js` IAM role, whose OIDC trust is bound to the new repository name, so the credential step would fail. Conversely, once the rename happens the old `ably-sdk-builds-ably-js` role stops matching, so this is a same-window change in both directions.

Sibling of [ably-pubsub-ruby#457](https://github.com/ably/ably-pubsub-ruby/pull/457), [ably-dotnet#1332](https://github.com/ably/ably-dotnet/pull/1332), [ably-python#682](https://github.com/ably/ably-python/pull/682) and [ably-java#1237](https://github.com/ably/ably-java/pull/1237). It only updates strings inside the repo; it does not rename anything.

## What changed

- **`.github/workflows/docs.yml`, `.github/workflows/bundle-report.yml`** — `role-to-assume` → `ably-sdk-builds-ably-pubsub-js`. The role is provisioned by [infrastructure#13005](https://github.com/ably/infrastructure/pull/13005) (merged 2026-09-01); [infrastructure#13054](https://github.com/ably/infrastructure/pull/13054) adds the ID-qualified OIDC subject GitHub uses for repos renamed after 2026-07-15.
- **`.github/workflows/features.yml`** — `repository-name: ably-pubsub-js`.
- **`package.json`** — `repository` and `bugs.url`. Package name `ably` untouched.
- **`src/fragments/license.js`** — the repository URL baked into the bundle licence header.
- **`src/common/lib/util/utils.ts`** — the modular-plugin remediation message links to the TypeDoc at `sdk.ably.com/builds/ably/<repo>/main/typedoc/…`. `ably/sdk-upload-action` derives that path from `github.repository`, so post-rename the docs land under `ably-pubsub-js` and the old path stops updating (no redirect on S3). Same fix in `README.md`.
- **`scripts/processPrivateApiData/utils.ts`** — strips the Actions workspace prefix `/home/runner/work/<repo>/<repo>/`, which follows the repo name. Without this the private-API report keeps absolute paths after the rename.
- **`README.md`** — licence badge, `package.json`/React docs/CHANGELOG links, and the support link, which pointed at `ably-js-nativescript/issues` (copy-paste slip) and now points at this repo's issues.
- **`CONTRIBUTING.md`** — title, `ably.d.ts` link, tags URL.
- **`typedoc/landing-page.md`** — source-code link on the API reference front page.
- **`.gitignore`** — `ably-js.iml` → `ably-pubsub-js.iml` (IDE file named after the checkout directory).

## Deliberately left as-is

- **`ably-js/<version>` agent identifier** (`src/common/lib/util/defaults.ts`) — a registered identifier, not a repository reference. The family rename to `ably-pubsub-js` lands with the split in #2297, gated on [ably-common#361](https://github.com/ably/ably-common/pull/361).
- **v2 migration-guide links** in `ably.d.ts` deprecation comments, `callbacks.js`/`promises.js` shims and `utils.ts:297` — GitHub's rename redirect covers them and `ably.d.ts` is heavily rewritten on the split branch; changing them here would only add conflicts.
- **`CHANGELOG.md`**, `docs/`, issue/PR links in code comments and tests — history; redirect covers them.
- **`publish-cdn.yml`** — assumes the shared `prod-ably-sdk-cdn` role, whose trust policy already lists `ably/ably-pubsub-js` (and gains the ID-qualified subject in infrastructure#13054). No change needed here.
- **CLAUDE.md** prose that calls the library "ably-js".

## Post-rename verification

- [ ] `git ls-remote` from an existing checkout and web redirects for repo / a PR / a file permalink.
- [ ] Full `check.yml` matrix green.
- [ ] `docs.yml`, `bundle-report.yml` and `features.yml` runs: AWS credential step succeeds **and the upload lands** at `sdk.ably.com/builds/ably/ably-pubsub-js/main/…` (the upload failure mode is silent).
- [ ] A `publish-cdn.yml` dry run or the next release confirms the CDN role still trusts the renamed repo.
- [ ] Merge `main` into the split/lockstep-release branches (#2268, #2297) which carry their own copies of the workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
