### PR TITLE
Reject annotation publish/delete without a type (RSAN1a3)

### DIFF
--- a/src/common/lib/client/restannotations.ts
+++ b/src/common/lib/client/restannotations.ts
@@ -57,6 +57,15 @@ export function constructValidateAnnotation(
   }
 
   const annotation = Annotation.fromValues(annotationValues);
+  if (!annotation.type || typeof annotation.type !== 'string') {
+    throw new ErrorInfo({
+      message: 'The annotation argument of annotations.' + methodName + '() must include a non-empty string `type`',
+      code: 40003,
+      statusCode: 400,
+      remediation:
+        'Set type on the annotation object, e.g. { type: "reaction:unique.v1", name: "👍" }. Other fields are optional.',
+    });
+  }
   annotation.messageSerial = messageSerial;
   if (!annotation.action) {
     annotation.action = 'annotation.create';

--- a/test/uts/deviations.md
+++ b/test/uts/deviations.md
@@ -86,18 +86,6 @@ These tests assert spec behavior but are skipped by default because they are kno
 
 ---
 
-### annotations: RSAN1a3 - type validation missing
-
-**Spec (RSAN1a3)**: The SDK must validate that the user supplied a `type`.
-
-**ably-js behavior**: `constructValidateAnnotation()` does not validate that `type` is present.
-
-**Tests**: `RSAN1a3 - type required` (realtime), `RTAN1a - publish validates type is required` (REST).
-
-**Issue**: [#2194](https://github.com/ably/ably-js/issues/2194)
-
----
-
 ### annotations: RSAN1c4 / RSC22d - idempotent IDs not generated
 
 **Spec (RSAN1c4)**: Annotations with empty `id` should get a generated idempotent ID. **Spec (RSC22d)**: Same for batch publish.

--- a/test/uts/realtime/unit/channels/channel_annotations.test.ts
+++ b/test/uts/realtime/unit/channels/channel_annotations.test.ts
@@ -610,10 +610,11 @@ describe('uts/realtime/unit/channels/channel_annotations', function () {
   /**
    * RTAN1a - publish validates type is required
    *
-   * Publishing an annotation without a type field should throw an error.
+   * Publishing an annotation without a type field should throw an error
+   * with code 40003.
    */
   // UTS: realtime/unit/RTAN1a/validates-type-required-1
-  it('RTAN1a - publish validates type is required (deviation: ably-js does not validate type client-side)', async function () {
+  it('RTAN1a - publish validates type is required', async function () {
     const { mock } = setupMock({
       onMessage: (msg, conn) => {
         if (msg.action === 21) {
@@ -642,22 +643,13 @@ describe('uts/realtime/unit/channels/channel_annotations', function () {
     const channel = client.channels.get('test-RTAN1a-validate', { attachOnSubscribe: false });
     await channel.attach();
 
-    // Deviation: ably-js does not validate that type is required client-side.
-    // The annotation is sent to the server without type validation.
-    if (!process.env.RUN_DEVIATIONS) {
-      this.skip();
-      return;
-    }
-
     try {
       await channel.annotations.publish('msg-serial-1', {
         name: 'like',
-        // type is missing
       } as any);
-      expect.fail('Should have thrown');
+      expect.fail('Expected publish without type to throw with code 40003');
     } catch (err: any) {
-      expect(err).to.exist;
-      expect(err.code).to.be.a('number');
+      expect(err.code).to.equal(40003);
     }
     client.close();
   });

--- a/test/uts/rest/unit/channel/annotations.test.ts
+++ b/test/uts/rest/unit/channel/annotations.test.ts
@@ -77,31 +77,18 @@ describe('uts/rest/unit/channel/annotations', function () {
    *
    * Publishing an annotation without a type field should throw an error
    * with code 40003.
-   *
-   * NOTE: ably-js does not currently validate the type field in
-   * constructValidateAnnotation(). This test documents the spec
-   * requirement (RSAN1a3) as a known deviation — the publish succeeds
-   * without a type instead of throwing.
    */
   // UTS: rest/unit/RSAN1a3/publish-type-required-0
   it('RSAN1a3 - type required', async function () {
-    // DEVIATION: see deviations.md
-    if (!process.env.RUN_DEVIATIONS) this.skip();
-    const captured: any[] = [];
     const mock = new MockHttpClient({
       onConnectionAttempt: (conn) => conn.respond_with_success(),
-      onRequest: (req) => {
-        captured.push(req);
-        req.respond_with(201, {});
-      },
+      onRequest: (req) => req.respond_with(201, {}),
     });
     installMockHttp(mock);
 
     const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
     const ch = client.channels.get('test');
 
-    // Spec (RSAN1a3): publishing without a type MUST throw with code 40003.
-    // DEVIATION: ably-js does not validate type. See deviations.md.
     try {
       await ch.annotations.publish('msg-serial-1', { name: 'like' });
       expect.fail('Expected publish without type to throw with code 40003');


### PR DESCRIPTION
`constructValidateAnnotation()` now rejects a missing, empty, or non-string `type` with `ErrorInfo` code 40003 / HTTP 400, matching RSAN1a3 and the existing serial / second-argument checks in the same helper.

Fixes #2194.

## Summary

REST `annotations.publish` / `delete` and realtime `annotations.publish` / `delete` all go through that helper. Unskipped the existing UTS tests (`RSAN1a3 - type required`, `RTAN1a - publish validates type is required`) and removed the RSAN1a3 entry from `test/uts/deviations.md`.

RSAN1a3 as quoted on #2194: the SDK must validate that the user supplied a `type`; all other fields are optional; throw 40003. Public `OutboundAnnotation` already required `type`; this is the runtime check.

## Decision

Validate in the shared helper, treating empty string like a missing serial (`!value || typeof !== 'string'`). The alternatives were to only reject a missing or non-string `type` (allow `type: ''`), or to validate only on the REST path. One helper is already the publish/delete gate for both clients, and the serial check next to it already uses that truthiness test.

Can drop the truthiness check if empty string should be left to the server.

## Test plan

- [x] `RSAN1a3 - type required` (REST UTS, mocked HTTP) throws 40003
- [x] `RTAN1a - publish validates type is required` (realtime UTS, mocked WebSocket) throws 40003
- [x] Same tests fail without the source change (publish succeeds; `error.code` is undefined)
- [x] Rest of `test/uts/rest/unit/channel/annotations.test.ts` (9 passing, 1 pending RSAN1c4) and `test/uts/realtime/unit/channels/channel_annotations.test.ts` (15 passing) still pass
- [ ] Type definitions unchanged (`OutboundAnnotation.type` was already required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing annotations now validates that the `type` field is a non-empty string.
  * Invalid or missing annotation types return a consistent error with code `40003` and HTTP status `400`.
  * Validation is applied consistently for both REST and realtime annotation publishing.

* **Tests**
  * Added coverage confirming the required validation behavior across REST and realtime publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->